### PR TITLE
Refactor

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -18,11 +18,12 @@
         "key-spacing": [ "error", { "beforeColon": false, "afterColon": true, "mode": "strict" } ],
         "semi-spacing": [ "error", {"before": false, "after": true} ],
         "comma-spacing": [ "error", { "before": false, "after": true } ],
-        "comma-dangle": ["error", "never"]
+        "comma-dangle": ["error", "never"],
+        "camelcase": "error",
+        "eqeqeq": "error"
     },
     "globals" : {
-        "_elm_community$elm_webgl$Native_WebGL": true,
-
+        "_elm_community$webgl$Native_WebGL": true,
         "_elm_lang$virtual_dom$Native_VirtualDom": false,
         "_elm_lang$core$List$map": false,
         "_elm_lang$core$List$length": false,


### PR DESCRIPTION
* Added more linting rules (`camelCase`, `eqeqeq` that already caught one `==`)
* Updated jsdoc comments on some functions 
* Moved dependencies to the top of the file
* Correctly unbind texture (the commented out code seemed wrong to me)
* Removed defensive `model.cache` setup, because `toHtml` sets this prop anyway