### PR TITLE
Added ability to specify options for the WebGL context

### DIFF
--- a/examples/first-person.elm
+++ b/examples/first-person.elm
@@ -277,13 +277,16 @@ view { size, person, texture } =
                 , ( "position", "relative" )
                 ]
             ]
-            [ WebGL.toHtml
+            [ WebGL.toHtmlWithEvenMore
+                { defaultContextAttributes | alpha = False }
+                defaultConfiguration
                 [ width size.width, height size.height, style [ ( "display", "block" ) ] ]
                 entities
             , div
                 [ style
                     [ ( "position", "absolute" )
                     , ( "font-family", "monospace" )
+                    , ( "color", "white" )
                     , ( "text-align", "center" )
                     , ( "left", "20px" )
                     , ( "right", "20px" )

--- a/src/Native/WebGL.js
+++ b/src/Native/WebGL.js
@@ -536,11 +536,12 @@ var _elm_community$webgl$Native_WebGL = function () {
 
   // VIRTUAL-DOM WIDGET
 
-  function toHtml(functionCalls, factList, renderables) {
+  function toHtml(contextAttributes, functionCalls, factList, renderables) {
     var model = {
       functionCalls: functionCalls,
       renderables: renderables,
-      cache: {}
+      cache: {},
+      contextAttributes: contextAttributes
     };
     // eslint-disable-next-line camelcase
     return _elm_lang$virtual_dom$Native_VirtualDom.custom(factList, model, implementation);
@@ -564,7 +565,7 @@ var _elm_community$webgl$Native_WebGL = function () {
 
     LOG('Render canvas');
     var canvas = document.createElement('canvas');
-    var gl = canvas.getContext && (canvas.getContext('webgl') || canvas.getContext('experimental-webgl'));
+    var gl = canvas.getContext && (canvas.getContext('webgl', model.contextAttributes) || canvas.getContext('experimental-webgl', model.contextAttributes));
 
     if (gl) {
       listMap(function (functionCall) {
@@ -607,7 +608,7 @@ var _elm_community$webgl$Native_WebGL = function () {
     textureSize: textureSize,
     loadTextureWithFilter: F2(loadTextureWithFilter),
     render: F5(render),
-    toHtml: F3(toHtml),
+    toHtml: F4(toHtml),
     enable: enable,
     disable: disable,
     blendColor: F4(blendColor),

--- a/src/WebGL.elm
+++ b/src/WebGL.elm
@@ -12,7 +12,7 @@ documentation provided here.
 @docs render, renderWithConfig
 
 # WebGL Html
-@docs toHtml, toHtmlWith, defaultConfiguration
+@docs toHtml, toHtmlWith, defaultConfiguration, WebGLContextAttributes, toHtmlWithEvenMore, defaultContextAttributes
 
 # WebGL API Calls
 @docs FunctionCall
@@ -178,8 +178,47 @@ meshes are cached so that they do not get resent to the GPU, so it should be
 relatively cheap to create new entities out of existing values.
 -}
 toHtmlWith : List FunctionCall -> List (Attribute msg) -> List Renderable -> Html msg
-toHtmlWith functionCalls =
-    Native.WebGL.toHtml (computeAPICalls functionCalls)
+toHtmlWith =
+    toHtmlWithEvenMore defaultContextAttributes
+
+
+{-|
+All possible options that you can specify when creating the WebGL context.
+See: https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/getContext
+or [the WebGL specs](https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.2)
+-}
+type alias WebGLContextAttributes =
+    { alpha : Bool
+    , depth : Bool
+    , stencil : Bool
+    , antialias : Bool
+    , premultipliedAlpha : Bool
+    }
+
+
+{-|
+The default WebGL context attributes.
+These are the same as [in the specs](https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.2)
+-}
+defaultContextAttributes : WebGLContextAttributes
+defaultContextAttributes =
+    { alpha = True
+    , depth = True
+    , stencil = False
+    , antialias = True
+    , premultipliedAlpha = True
+    }
+
+
+{-|
+The same as toHtmlWith, but with this version you can also specify attributes for the WebGL context.
+This is needed if you need specific features, e.g. the stencil buffer.
+See: https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/getContext
+or [the WebGL specs](https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.2)
+-}
+toHtmlWithEvenMore : WebGLContextAttributes -> List FunctionCall -> List (Attribute msg) -> List Renderable -> Html msg
+toHtmlWithEvenMore contextAttributes functionCalls =
+    Native.WebGL.toHtml contextAttributes (computeAPICalls functionCalls)
 
 
 {-| -}


### PR DESCRIPTION
Replaying [the original pull request](https://github.com/elm-community/elm-webgl/pull/38) by @Zinggi on top of the current master.

I've only squashed commits and rebased the branch.

This pull request addresses the following issues:

* [There is no way to specify WebGL context attributes ](https://github.com/johnpmayer/elm-webgl/issues/40)
* [Add support to disable premultipliedAlpha](https://github.com/elm-community/elm-webgl/issues/19)

Quoting the original pull request:

> 
> As discussed in https://github.com/elm-community/elm-webgl/issues/19, I added a function `toHtmlWithEvenMore` that makes it possible to set some of the attributes outlined [here](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/getContext) and [section 5.2 of the specs](https://www.khronos.org/registry/webgl/specs/latest/1.0/).
> 
> I didn't allow all attributes because I don't know whether they would even be useful from elm.
> 
> If you have a better name than `toHtmlWithEvenMore` than I can change it if needed.
> 
> I also took the liberty to modify the fps example, because it seems like a good candidate for showing off the new available settings. E.g. for an fps I think it makes sense to disable alpha.
> 