### PR TITLE
Added useful missing function calls

### DIFF
--- a/src/Native/WebGL.js
+++ b/src/Native/WebGL.js
@@ -275,7 +275,7 @@ var _elm_community$webgl$Native_WebGL = function () {
     }
 
     gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight);
-    gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+    gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT | gl.STENCIL_BUFFER_BIT);
     LOG('Drawing');
 
     function drawEntity(render) {
@@ -495,6 +495,10 @@ var _elm_community$webgl$Native_WebGL = function () {
     };
   }
 
+  function depthMask(mask) {
+    return function (gl) { gl.depthMask(mask); };
+  }
+
   function sampleCoverage(value, invert) {
     return function (gl) {
       gl.sampleCoverage(value, invert);
@@ -522,6 +526,24 @@ var _elm_community$webgl$Native_WebGL = function () {
   function stencilOperationSeparate(face, fail, zfail, zpass) {
     return function (gl) {
       gl.stencilOpSeparate(gl[face], gl[fail], gl[zfail], gl[zpass]);
+    };
+  }
+
+  function stencilMask(mask) {
+    return function (gl) {
+      gl.stencilMask(mask);
+    };
+  }
+
+  function colorMask(r, g, b, a) {
+    return function (gl) {
+      gl.colorMask(r, g, b, a);
+    };
+  }
+
+  function scissor(x, y, w, h) {
+    return function (gl) {
+      gl.scissor(x, y, w, h);
     };
   }
 
@@ -607,11 +629,15 @@ var _elm_community$webgl$Native_WebGL = function () {
     blendEquationSeparate: F2(blendEquationSeparate),
     blendFunc: F2(blendFunc),
     depthFunc: depthFunc,
+    depthMask: depthMask,
     sampleCoverage: F2(sampleCoverage),
     stencilFunc: F3(stencilFunc),
     stencilFuncSeparate: F4(stencilFuncSeparate),
     stencilOperation: F3(stencilOperation),
-    stencilOperationSeparate: F4(stencilOperationSeparate)
+    stencilOperationSeparate: F4(stencilOperationSeparate),
+    stencilMask: stencilMask,
+    colorMask: F4(colorMask),
+    scissor: F4(scissor)
   };
 
 }();

--- a/src/WebGL.elm
+++ b/src/WebGL.elm
@@ -233,6 +233,9 @@ computeAPICall function =
             computeCompareModeString mode
                 |> Native.WebGL.depthFunc
 
+        DepthMask mask ->
+            Native.WebGL.depthMask mask
+
         SampleCoverageFunc ( value, invert ) ->
             Native.WebGL.sampleCoverage value invert
 
@@ -282,6 +285,15 @@ computeAPICall function =
             in
                 Native.WebGL.stencilOperationSeparate face fail zfail zpass
 
+        StencilMask mask ->
+            Native.WebGL.stencilMask mask
+
+        ColorMask ( r, g, b, a ) ->
+            Native.WebGL.colorMask r g b a
+
+        Scissor ( x, y, w, h ) ->
+            Native.WebGL.scissor x y w h
+
 
 {-| The `FunctionCall` provides a typesafe way to call
 all pre-fragment operations and some special functions.
@@ -315,6 +327,11 @@ and alpha source blending factors are computed
 and alpha destination blending factors are computed
 + `SrcAlphaSaturate` should only be used for the srcFactor);
 + Both values may not reference a `ConstantColor` value;
+
+`DepthMask(mask: Int)`
++ set the mask for the depth buffer. Any value drawn to the
++ depth buffer will be ANDed with the mask. Usually used to
++ turn drawing to the depth buffer on or off.
 
 `SampleCoverageFunc(value: Float, invert: Bool)`
 + specify multisample coverage parameters
@@ -353,6 +370,21 @@ The initial value is `Keep`
 + set front and/or back stencil test actions
 + `face`: Specifies whether front and/or back stencil state is updated.
 + See the description of `StencilOperation` for info about the other parameters.
+
+`StencilMask(mask: Int)`
++ set the stencil mask. This value is ANDed with anything drawn to the
++ stencil buffer. Usually used to turn writing to the stencil buffer
++ on or off.
+
+`ColorMask(r: Int, g: Int, b: Int, a: Int)`
++ set mask to be applied to anything drawn to the color buffer.
++ Values drawn to each channel will be ANDed with their
++ color mask respectively.
+
+`Scissor(x: Int, y: Int, width: Int, height: Int)`
++ set the scissor box, which limits the drawing of fragments to the
++ screen to a specified rectangle.
+
 -}
 type FunctionCall
     = Enable Capability
@@ -362,11 +394,15 @@ type FunctionCall
     | BlendEquationSeparate ( BlendMode, BlendMode )
     | BlendFunc ( BlendOperation, BlendOperation )
     | DepthFunc CompareMode
+    | DepthMask Int
     | SampleCoverageFunc ( Float, Bool )
     | StencilFunc ( CompareMode, Int, Int )
     | StencilFuncSeparate ( FaceMode, CompareMode, Int, Int )
     | StencilOperation ( ZMode, ZMode, ZMode )
     | StencilOperationSeparate ( FaceMode, ZMode, ZMode, ZMode )
+    | StencilMask Int
+    | ColorMask ( Int, Int, Int, Int )
+    | Scissor ( Int, Int, Int, Int )
 
 
 {-| -}


### PR DESCRIPTION
I rebased [the original pull request](https://github.com/elm-community/elm-webgl/pull/32) by @emptyflash from elm-webgl.

I did not pick the change that sets the stencil context attribute, because this is done in #4 pull request. 

Quoting the original PR:
> 
> I wanted to get y'all's eyes on this.
> 
> I implemented these function calls in my fork so I could do some of the things I wanted to do.
> Went ahead and documented them in case y'all want to merge for the next version bump.
> 
> There's also the matter of the missing context attributes for the stencil buffer,
>  i.e. : `canvas.getContext('webgl', {stencil: true})`.
> This is a little more important because none of the stencil function calls will work with out it.
> I can submit that part as separate PR if that would be preferred.
> 