### PR TITLE
Fix texture filtering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ index.html
 .DS_Store
 gh-pages
 node_modules
+elm.js

--- a/examples/thwomp.elm
+++ b/examples/thwomp.elm
@@ -87,10 +87,10 @@ main =
 
 fetchTextures : Task Error ( Maybe Texture, Maybe Texture )
 fetchTextures =
-    loadTexture "texture/thwomp_face.jpg"
+    loadTextureWithFilter Nearest "texture/thwomp_face.jpg"
         |> Task.andThen
             (\faceTexture ->
-                loadTexture "texture/thwomp_side.jpg"
+                loadTextureWithFilter Nearest "texture/thwomp_side.jpg"
                     |> Task.andThen
                         (\sideTexture ->
                             Task.succeed ( Just faceTexture, Just sideTexture )

--- a/src/Native/WebGL.js
+++ b/src/Native/WebGL.js
@@ -23,7 +23,7 @@ var _elm_community$webgl$Native_WebGL = function () {
     return { src: src };
   }
 
-  function loadTexture(source) {
+  function loadTextureWithFilter(filter, source) {
     return Scheduler.nativeBinding(function (callback) {
       var img = new Image();
       // prevent the debugger from serializing the image as a record
@@ -34,29 +34,7 @@ var _elm_community$webgl$Native_WebGL = function () {
         callback(Scheduler.succeed({
           ctor: 'Texture',
           img: getImage,
-          width: img.width,
-          height: img.height
-        }));
-      };
-      img.onerror = function () {
-        callback(Scheduler.fail({ ctor: 'Error' }));
-      };
-      img.crossOrigin = 'Anonymous';
-      img.src = source;
-    });
-  }
-
-  function loadTextureRaw(filter, source) {
-    return Scheduler.nativeBinding(function (callback) {
-      var img = new Image();
-      // prevent the debugger from serializing the image as a record
-      function getImage() {
-        return img;
-      }
-      img.onload = function () {
-        callback(Scheduler.succeed({
-          ctor: 'RawTexture',
-          img: getImage,
+          filter: filter,
           width: img.width,
           height: img.height
         }));
@@ -97,12 +75,12 @@ var _elm_community$webgl$Native_WebGL = function () {
     gl.bindTexture(gl.TEXTURE_2D, tex);
     gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, true);
     gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, texture.img());
-    switch (texture.ctor) {
-      case 'Texture':
+    switch (texture.filter.ctor) {
+      case 'Linear':
         gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
         gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
         break;
-      case 'RawTexture':
+      case 'Nearest':
         gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
         gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
         break;
@@ -619,7 +597,7 @@ var _elm_community$webgl$Native_WebGL = function () {
   return {
     unsafeCoerceGLSL: unsafeCoerceGLSL,
     textureSize: textureSize,
-    loadTexture: loadTexture,
+    loadTextureWithFilter: F2(loadTextureWithFilter),
     render: F5(render),
     toHtml: F3(toHtml),
     enable: enable,
@@ -633,8 +611,7 @@ var _elm_community$webgl$Native_WebGL = function () {
     stencilFunc: F3(stencilFunc),
     stencilFuncSeparate: F4(stencilFuncSeparate),
     stencilOperation: F3(stencilOperation),
-    stencilOperationSeparate: F4(stencilOperationSeparate),
-    loadTextureRaw: F2(loadTextureRaw)
+    stencilOperationSeparate: F4(stencilOperationSeparate)
   };
 
 }();

--- a/src/WebGL.elm
+++ b/src/WebGL.elm
@@ -115,8 +115,8 @@ loadTexture =
 other formats have not been as well-tested yet. Configurable filter.
 -}
 loadTextureWithFilter : TextureFilter -> String -> Task Error Texture
-loadTextureWithFilter filter url =
-    Native.WebGL.loadTextureRaw Linear url
+loadTextureWithFilter =
+    Native.WebGL.loadTextureWithFilter
 
 
 {-| Return the (width, height) size of a texture. Useful for sprite sheets


### PR DESCRIPTION
This is a rebase of [this pull request](https://github.com/johnpmayer/elm-webgl/pull/35) by @skrat.

Quoting the original PR:

> Loading textures was broken. I fixed it by removing `loadTextureRaw` and actually using the `TextureFilter` type, which was there, but wasn't used anywhere. Now it is. Also the `thwomp.elm` example is fixed.

Since this is a patch change, we can merge this.

Bonus point: it deletes some native code.
