### PR TITLE
Extract texture module

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,6 +23,7 @@
         "eqeqeq": "error"
     },
     "globals" : {
+        "_elm_community$webgl$Native_Texture": true,
         "_elm_community$webgl$Native_WebGL": true,
         "_elm_lang$virtual_dom$Native_VirtualDom": false,
         "_elm_lang$core$Native_Utils": false,

--- a/elm-package.json
+++ b/elm-package.json
@@ -7,7 +7,8 @@
         "src"
     ],
     "exposed-modules": [
-        "WebGL"
+        "WebGL",
+        "WebGL.Texture"
     ],
     "native-modules": true,
     "dependencies": {

--- a/examples/crate.elm
+++ b/examples/crate.elm
@@ -6,6 +6,7 @@ import Math.Matrix4 exposing (..)
 import Task
 import Time exposing (Time)
 import WebGL exposing (..)
+import WebGL.Texture as Texture exposing (Error)
 import Html exposing (Html)
 import AnimationFrame
 import Html.Attributes exposing (width, height)
@@ -39,7 +40,7 @@ update action model =
 init : ( Model, Cmd Action )
 init =
     ( { texture = Nothing, theta = 0 }
-    , loadTexture "texture/woodCrate.jpg"
+    , Texture.load "texture/woodCrate.jpg"
         |> Task.attempt
             (\result ->
                 case result of

--- a/examples/first-person.elm
+++ b/examples/first-person.elm
@@ -11,6 +11,7 @@ import Math.Matrix4 exposing (..)
 import Task exposing (Task)
 import Time exposing (..)
 import WebGL exposing (..)
+import WebGL.Texture as Texture exposing (Error)
 import Html exposing (Html, text, div)
 import Html
 import Html.Attributes exposing (width, height, style)
@@ -100,7 +101,7 @@ init =
       , size = Window.Size 0 0
       }
     , Cmd.batch
-        [ loadTexture "texture/woodCrate.jpg"
+        [ Texture.load "texture/woodCrate.jpg"
             |> Task.attempt
                 (\result ->
                     case result of

--- a/examples/thwomp.elm
+++ b/examples/thwomp.elm
@@ -10,6 +10,7 @@ import Math.Matrix4 exposing (..)
 import Mouse
 import Task exposing (Task)
 import WebGL exposing (..)
+import WebGL.Texture as Texture exposing (Error)
 import Window
 import Html exposing (Html)
 import Html.Attributes exposing (width, height)
@@ -87,10 +88,10 @@ main =
 
 fetchTextures : Task Error ( Maybe Texture, Maybe Texture )
 fetchTextures =
-    loadTextureWithFilter Nearest "texture/thwomp_face.jpg"
+    Texture.loadWith Texture.Nearest "texture/thwomp_face.jpg"
         |> Task.andThen
             (\faceTexture ->
-                loadTextureWithFilter Nearest "texture/thwomp_side.jpg"
+                Texture.loadWith Texture.Nearest "texture/thwomp_side.jpg"
                     |> Task.andThen
                         (\sideTexture ->
                             Task.succeed ( Just faceTexture, Just sideTexture )

--- a/src/Native/Texture.js
+++ b/src/Native/Texture.js
@@ -1,0 +1,40 @@
+// eslint-disable-next-line no-unused-vars, camelcase
+var _elm_community$webgl$Native_Texture = function () {
+
+  function loadWith(filter, source) {
+    // eslint-disable-next-line camelcase
+    var Scheduler = _elm_lang$core$Native_Scheduler;
+    return Scheduler.nativeBinding(function (callback) {
+      var img = new Image();
+      // prevent the debugger from serializing the image as a record
+      function getImage() {
+        return img;
+      }
+      img.onload = function () {
+        callback(Scheduler.succeed({
+          ctor: 'Texture',
+          img: getImage,
+          filter: filter,
+          width: img.width,
+          height: img.height
+        }));
+      };
+      img.onerror = function () {
+        callback(Scheduler.fail({ ctor: 'Error' }));
+      };
+      img.crossOrigin = 'Anonymous';
+      img.src = source;
+    });
+  }
+
+  function size(texture) {
+    // eslint-disable-next-line camelcase
+    return _elm_lang$core$Native_Utils.Tuple2(texture.width, texture.height);
+  }
+
+  return {
+    size: size,
+    loadWith: F2(loadWith)
+  };
+
+}();

--- a/src/WebGL.elm
+++ b/src/WebGL.elm
@@ -1,10 +1,8 @@
 module WebGL
     exposing
         ( Texture
-        , TextureFilter(..)
         , Shader
         , Renderable
-        , Error
         , Drawable(..)
         , render
         , renderWithConfig
@@ -19,9 +17,6 @@ module WebGL
         , FaceMode(..)
         , ZMode(..)
         , unsafeShader
-        , loadTexture
-        , loadTextureWithFilter
-        , textureSize
         , WebGLContextAttributes
         , defaultContextAttributes
         , toHtmlWithEvenMore
@@ -33,7 +28,7 @@ and look at some examples before trying to do too much with just the
 documentation provided here.
 
 # Main Types
-@docs Texture, TextureFilter, Shader, Renderable, Error, Drawable
+@docs Shader, Renderable, Drawable, Texture
 
 # Entities
 @docs render, renderWithConfig
@@ -47,16 +42,12 @@ documentation provided here.
 # WebGL API Types
 @docs Capability, BlendOperation, BlendMode, CompareMode, FaceMode, ZMode
 
-# Loading Textures
-@docs loadTexture, loadTextureWithFilter, textureSize
-
 # Unsafe Shader Creation (for library writers)
 @docs unsafeShader
 
 -}
 
 import Html exposing (Html, Attribute)
-import Task exposing (Task)
 import List
 import Native.WebGL
 
@@ -112,47 +103,10 @@ unsafeShader =
 
 
 {-| `Texture` is a phantom data type, can be
-created with `loadTexture` or `loadTextureWithFilter`
+created with `Texture.load` or `Texture.loadWith`
 -}
 type Texture
     = Texture
-
-
-{-| Textures work in two ways when looking up a pixel value - Linear or Nearest
--}
-type TextureFilter
-    = Linear
-    | Nearest
-
-
-{-| An error which occured in the graphics context
--}
-type Error
-    = Error
-
-
-{-| Loads a texture from the given url with Linear filtering.
-PNG and JPEG are known to work, but other formats have not been as well-tested yet.
--}
-loadTexture : String -> Task Error Texture
-loadTexture =
-    loadTextureWithFilter Linear
-
-
-{-| Loads a texture from the given url. PNG and JPEG are known to work, but
-other formats have not been as well-tested yet. Configurable filter.
--}
-loadTextureWithFilter : TextureFilter -> String -> Task Error Texture
-loadTextureWithFilter =
-    Native.WebGL.loadTextureWithFilter
-
-
-{-| Return the (width, height) size of a texture. Useful for sprite sheets
-or other times you may want to use only a potion of a texture image.
--}
-textureSize : Texture -> ( Int, Int )
-textureSize =
-    Native.WebGL.textureSize
 
 
 {-| Conceptually, an encapsulataion of the instructions to render something

--- a/src/WebGL/Texture.elm
+++ b/src/WebGL/Texture.elm
@@ -1,0 +1,67 @@
+module WebGL.Texture
+    exposing
+        ( Texture
+        , Error
+        , TextureFilter(..)
+        , load
+        , loadWith
+        , size
+        )
+
+{-|
+
+# Types
+@docs Texture, TextureFilter, Error
+
+# Loading Textures
+@docs load, loadWith, size
+
+-}
+
+import Task exposing (Task)
+import WebGL
+import Native.Texture
+
+
+{-| `Texture` is a phantom data type, can be
+created with `load` or `loadWith`
+-}
+type alias Texture =
+    WebGL.Texture
+
+
+{-| Textures work in two ways when looking up a pixel value - Linear or Nearest
+-}
+type TextureFilter
+    = Linear
+    | Nearest
+
+
+{-| An error which occured while loading a texture
+-}
+type Error
+    = Error
+
+
+{-| Loads a texture from the given url with Linear filtering.
+PNG and JPEG are known to work, but other formats have not been as well-tested yet.
+-}
+load : String -> Task Error Texture
+load =
+    loadWith Linear
+
+
+{-| Loads a texture from the given url. PNG and JPEG are known to work, but
+other formats have not been as well-tested yet. Configurable filter.
+-}
+loadWith : TextureFilter -> String -> Task Error Texture
+loadWith =
+    Native.Texture.loadWith
+
+
+{-| Return the (width, height) size of a texture. Useful for sprite sheets
+or other times you may want to use only a potion of a texture image.
+-}
+size : Texture -> ( Int, Int )
+size =
+    Native.Texture.size


### PR DESCRIPTION
Extracted `Texture` in a separate module. The type constructor has to be kept in WebGL, because it is hardcoded in the elm-compiler