### PR TITLE
Do not export type constructors

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -25,6 +25,7 @@
     "globals" : {
         "_elm_community$webgl$Native_Texture": true,
         "_elm_community$webgl$Native_WebGL": true,
+        "_elm_community$webgl$Native_Settings": true,
         "_elm_lang$virtual_dom$Native_VirtualDom": false,
         "_elm_lang$core$Native_Utils": false,
         "_elm_lang$core$Native_Scheduler": false,

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ gh-pages
 release
 node_modules
 elm.js
+documentation.json

--- a/elm-package.json
+++ b/elm-package.json
@@ -8,7 +8,9 @@
     ],
     "exposed-modules": [
         "WebGL",
-        "WebGL.Texture"
+        "WebGL.Texture",
+        "WebGL.Settings",
+        "WebGL.Constants"
     ],
     "native-modules": true,
     "dependencies": {

--- a/examples/crate.elm
+++ b/examples/crate.elm
@@ -69,7 +69,7 @@ main =
 
 crate : Drawable { pos : Vec3, coord : Vec3 }
 crate =
-    Triangles <|
+    triangles <|
         List.concatMap rotatedFace [ ( 0, 0 ), ( 90, 0 ), ( 180, 0 ), ( 270, 0 ), ( 0, 90 ), ( 0, -90 ) ]
 
 

--- a/examples/cube.elm
+++ b/examples/cube.elm
@@ -59,7 +59,7 @@ cube =
         lbb =
             vec3 -1 -1 -1
     in
-        Triangles
+        triangles
             << List.concat
         <|
             [ face green rft rfb rbb rbt

--- a/examples/first-person.elm
+++ b/examples/first-person.elm
@@ -316,7 +316,7 @@ type alias Vertex =
 
 crate : Drawable Vertex
 crate =
-    Triangles (List.concatMap rotatedFace [ ( 0, 0 ), ( 90, 0 ), ( 180, 0 ), ( 270, 0 ), ( 0, 90 ), ( 0, -90 ) ])
+    triangles (List.concatMap rotatedFace [ ( 0, 0 ), ( 90, 0 ), ( 180, 0 ), ( 270, 0 ), ( 0, 90 ), ( 0, -90 ) ])
 
 
 rotatedFace : ( Float, Float ) -> List ( Vertex, Vertex, Vertex )

--- a/examples/firstrender_bug.elm
+++ b/examples/firstrender_bug.elm
@@ -24,7 +24,7 @@ type alias Vertex =
 
 heroVertices : WebGL.Drawable Vertex
 heroVertices =
-    WebGL.Triangles
+    WebGL.triangles
         [ ( { pos = Vec3.vec3 0 0 0 }
           , { pos = Vec3.vec3 1 1 0 }
           , { pos = Vec3.vec3 1 -1 0 }

--- a/examples/mouse_bug.elm
+++ b/examples/mouse_bug.elm
@@ -25,7 +25,7 @@ type alias Vertex =
 
 mesh : GL.Drawable Vertex
 mesh =
-    GL.IndexedTriangles
+    GL.indexedTriangles
         [ Vertex (vec2 0 0) (vec3 1 0 0)
         , Vertex (vec2 1 1) (vec3 0 1 0)
         , Vertex (vec2 1 0) (vec3 0 0 1)

--- a/examples/thwomp.elm
+++ b/examples/thwomp.elm
@@ -215,7 +215,7 @@ toEntity mesh response perspective =
     response
         |> Maybe.map
             (\texture ->
-                [ render vertexShader fragmentShader (Triangles mesh) { texture = texture, perspective = perspective } ]
+                [ render vertexShader fragmentShader (triangles mesh) { texture = texture, perspective = perspective } ]
             )
         |> Maybe.withDefault []
 

--- a/examples/triangle.elm
+++ b/examples/triangle.elm
@@ -3,6 +3,8 @@ module Main exposing (..)
 import Math.Vector3 exposing (..)
 import Math.Matrix4 exposing (..)
 import WebGL exposing (..)
+import WebGL.Settings as Settings
+import WebGL.Constants as Constants
 import Html exposing (Html)
 import Html.Attributes exposing (width, height)
 import AnimationFrame
@@ -18,7 +20,7 @@ type alias Vertex =
 
 mesh : Drawable Vertex
 mesh =
-    Triangles
+    triangles
         [ ( Vertex (vec3 0 0 0) (vec3 1 0 0)
           , Vertex (vec3 1 1 0) (vec3 0 1 0)
           , Vertex (vec3 1 -1 0) (vec3 0 0 1)
@@ -39,7 +41,9 @@ main =
 view : Float -> Html msg
 view t =
     WebGL.toHtmlWith
-        [ Enable DepthTest, ClearColor ( 0, 0, 0, 1 ) ]
+        [ Settings.enable Constants.depthTest
+        , Settings.clearColor 0 0 0 1
+        ]
         [ width 400, height 400 ]
         [ render vertexShader fragmentShader mesh { perspective = perspective (t / 1000) } ]
 

--- a/src/Native/Settings.js
+++ b/src/Native/Settings.js
@@ -1,0 +1,125 @@
+// eslint-disable-next-line no-unused-vars, camelcase
+var _elm_community$webgl$Native_Settings = function () {
+
+  function enable(capability) {
+    return function (gl) {
+      gl.enable(gl[capability]);
+    };
+  }
+
+  function disable(capability) {
+    return function (gl) {
+      gl.disable(gl[capability]);
+    };
+  }
+
+  function blendColor(r, g, b, a) {
+    return function (gl) {
+      gl.blendColor(r, g, b, a);
+    };
+  }
+
+  function blendEquation(mode) {
+    return function (gl) {
+      gl.blendEquation(gl[mode]);
+    };
+  }
+
+  function blendEquationSeparate(modeRGB, modeAlpha) {
+    return function (gl) {
+      gl.blendEquationSeparate(gl[modeRGB], gl[modeAlpha]);
+    };
+  }
+
+  function blendFunc(src, dst) {
+    return function (gl) {
+      gl.blendFunc(gl[src], gl[dst]);
+    };
+  }
+
+  function clearColor(r, g, b, a) {
+    return function (gl) {
+      gl.clearColor(r, g, b, a);
+    };
+  }
+
+  function depthFunc(mode) {
+    return function (gl) {
+      gl.depthFunc(gl[mode]);
+    };
+  }
+
+  function depthMask(mask) {
+    return function (gl) { gl.depthMask(mask); };
+  }
+
+  function sampleCoverage(value, invert) {
+    return function (gl) {
+      gl.sampleCoverage(value, invert);
+    };
+  }
+
+  function stencilFunc(func, ref, mask) {
+    return function (gl) {
+      gl.stencilFunc(gl[func], ref, mask);
+    };
+  }
+
+  function stencilFuncSeparate(face, func, ref, mask) {
+    return function (gl) {
+      gl.stencilFuncSeparate(gl[face], gl[func], ref, mask);
+    };
+  }
+
+  function stencilOperation(fail, zfail, zpass) {
+    return function (gl) {
+      gl.stencilOp(gl[fail], gl[zfail], gl[zpass]);
+    };
+  }
+
+  function stencilOperationSeparate(face, fail, zfail, zpass) {
+    return function (gl) {
+      gl.stencilOpSeparate(gl[face], gl[fail], gl[zfail], gl[zpass]);
+    };
+  }
+
+  function stencilMask(mask) {
+    return function (gl) {
+      gl.stencilMask(mask);
+    };
+  }
+
+  function colorMask(r, g, b, a) {
+    return function (gl) {
+      gl.colorMask(r, g, b, a);
+    };
+  }
+
+  function scissor(x, y, w, h) {
+    return function (gl) {
+      gl.scissor(x, y, w, h);
+    };
+  }
+
+
+  return {
+    enable: enable,
+    disable: disable,
+    blendColor: F4(blendColor),
+    blendEquation: blendEquation,
+    blendEquationSeparate: F2(blendEquationSeparate),
+    blendFunc: F2(blendFunc),
+    clearColor: F4(clearColor),
+    depthFunc: depthFunc,
+    depthMask: depthMask,
+    sampleCoverage: F2(sampleCoverage),
+    stencilFunc: F3(stencilFunc),
+    stencilFuncSeparate: F4(stencilFuncSeparate),
+    stencilOperation: F3(stencilOperation),
+    stencilOperationSeparate: F4(stencilOperationSeparate),
+    stencilMask: stencilMask,
+    colorMask: F4(colorMask),
+    scissor: F4(scissor)
+  };
+
+}();

--- a/src/Native/WebGL.js
+++ b/src/Native/WebGL.js
@@ -35,44 +35,14 @@ var _elm_community$webgl$Native_WebGL = function () {
     return { src: src };
   }
 
-  function loadTextureWithFilter(filter, source) {
-    // eslint-disable-next-line camelcase
-    var Scheduler = _elm_lang$core$Native_Scheduler;
-    return Scheduler.nativeBinding(function (callback) {
-      var img = new Image();
-      // prevent the debugger from serializing the image as a record
-      function getImage() {
-        return img;
-      }
-      img.onload = function () {
-        callback(Scheduler.succeed({
-          ctor: 'Texture',
-          img: getImage,
-          filter: filter,
-          width: img.width,
-          height: img.height
-        }));
-      };
-      img.onerror = function () {
-        callback(Scheduler.fail({ ctor: 'Error' }));
-      };
-      img.crossOrigin = 'Anonymous';
-      img.src = source;
-    });
-  }
-
-  function textureSize(texture) {
-    // eslint-disable-next-line camelcase
-    return _elm_lang$core$Native_Utils.Tuple2(texture.width, texture.height);
-  }
-
-  function render(vert, frag, buffer, uniforms, functionCalls) {
+  function render(functionCalls, vert, frag, buffer, uniforms) {
 
     if (!buffer.guid) {
       buffer.guid = guid();
     }
 
     return {
+      ctor: 'Renderable',
       vert: vert,
       frag: frag,
       buffer: buffer,
@@ -500,107 +470,6 @@ var _elm_community$webgl$Native_WebGL = function () {
     });
   }
 
-  function enable(capability) {
-    return function (gl) {
-      gl.enable(gl[capability]);
-    };
-  }
-
-  function disable(capability) {
-    return function (gl) {
-      gl.disable(gl[capability]);
-    };
-  }
-
-  function blendColor(r, g, b, a) {
-    return function (gl) {
-      gl.blendColor(r, g, b, a);
-    };
-  }
-
-  function blendEquation(mode) {
-    return function (gl) {
-      gl.blendEquation(gl[mode]);
-    };
-  }
-
-  function blendEquationSeparate(modeRGB, modeAlpha) {
-    return function (gl) {
-      gl.blendEquationSeparate(gl[modeRGB], gl[modeAlpha]);
-    };
-  }
-
-  function blendFunc(src, dst) {
-    return function (gl) {
-      gl.blendFunc(gl[src], gl[dst]);
-    };
-  }
-
-  function clearColor(r, g, b, a) {
-    return function (gl) {
-      gl.clearColor(r, g, b, a);
-    };
-  }
-
-  function depthFunc(mode) {
-    return function (gl) {
-      gl.depthFunc(gl[mode]);
-    };
-  }
-
-  function depthMask(mask) {
-    return function (gl) { gl.depthMask(mask); };
-  }
-
-  function sampleCoverage(value, invert) {
-    return function (gl) {
-      gl.sampleCoverage(value, invert);
-    };
-  }
-
-  function stencilFunc(func, ref, mask) {
-    return function (gl) {
-      gl.stencilFunc(gl[func], ref, mask);
-    };
-  }
-
-  function stencilFuncSeparate(face, func, ref, mask) {
-    return function (gl) {
-      gl.stencilFuncSeparate(gl[face], gl[func], ref, mask);
-    };
-  }
-
-  function stencilOperation(fail, zfail, zpass) {
-    return function (gl) {
-      gl.stencilOp(gl[fail], gl[zfail], gl[zpass]);
-    };
-  }
-
-  function stencilOperationSeparate(face, fail, zfail, zpass) {
-    return function (gl) {
-      gl.stencilOpSeparate(gl[face], gl[fail], gl[zfail], gl[zpass]);
-    };
-  }
-
-  function stencilMask(mask) {
-    return function (gl) {
-      gl.stencilMask(mask);
-    };
-  }
-
-  function colorMask(r, g, b, a) {
-    return function (gl) {
-      gl.colorMask(r, g, b, a);
-    };
-  }
-
-  function scissor(x, y, w, h) {
-    return function (gl) {
-      gl.scissor(x, y, w, h);
-    };
-  }
-
-
   // VIRTUAL-DOM WIDGET
 
   function toHtml(contextAttributes, functionCalls, factList, renderables) {
@@ -672,27 +541,8 @@ var _elm_community$webgl$Native_WebGL = function () {
 
   return {
     unsafeCoerceGLSL: unsafeCoerceGLSL,
-    textureSize: textureSize,
-    loadTextureWithFilter: F2(loadTextureWithFilter),
     render: F5(render),
-    toHtml: F4(toHtml),
-    enable: enable,
-    disable: disable,
-    blendColor: F4(blendColor),
-    blendEquation: blendEquation,
-    blendEquationSeparate: F2(blendEquationSeparate),
-    blendFunc: F2(blendFunc),
-    clearColor: F4(clearColor),
-    depthFunc: depthFunc,
-    depthMask: depthMask,
-    sampleCoverage: F2(sampleCoverage),
-    stencilFunc: F3(stencilFunc),
-    stencilFuncSeparate: F4(stencilFuncSeparate),
-    stencilOperation: F3(stencilOperation),
-    stencilOperationSeparate: F4(stencilOperationSeparate),
-    stencilMask: stencilMask,
-    colorMask: F4(colorMask),
-    scissor: F4(scissor)
+    toHtml: F4(toHtml)
   };
 
 }();

--- a/src/WebGL/Constants.elm
+++ b/src/WebGL/Constants.elm
@@ -1,0 +1,400 @@
+module WebGL.Constants exposing (..)
+
+{-|
+# Capabilities
+
+@docs Capability, blend, cullFace, depthTest, dither, polygonOffsetFill, sampleAlphaToCoverage, sampleCoverage, scissorTest, stencilTest
+
+# Blend Operations
+
+@docs BlendOperation, zero, one, srcColor, oneMinusSrcColor, dstColor, oneMinusDstColor, srcAlpha, oneMinusSrcAlpha, dstAlpha, oneMinusDstAlpha, constantColor, oneMinusConstantColor, constantAlpha, oneMinusConstantAlpha, srcAlphaSaturate
+
+# Blend Modes
+
+@docs BlendMode, add, subtract, reverseSubtract
+
+# Compare Modes
+
+@docs CompareMode, never, always, less, lessOrEqual, equal, greaterOrEqual, greater, notEqual
+
+# Face Modes
+
+@docs FaceMode, front, back, frontAndBack
+
+# ZModes
+
+@docs ZMode, keep, none, replace, increment, decrement, invert, incrementWrap, decrementWrap
+-}
+
+import WebGL.Types as Types exposing (..)
+
+
+{-| The `Capability` is used to enable/disable
+server-side GL capabilities.
+-}
+type alias Capability =
+    Types.Capability
+
+
+{-| Blend the computed fragment color values
+with the values in the color buffers.
+-}
+blend : Capability
+blend =
+    Blend
+
+
+{-| Cull polygons based on their winding in window coordinates.
+-}
+cullFace : Capability
+cullFace =
+    CullFace
+
+
+{-| Do depth comparisons and update the depth buffer.
+-}
+depthTest : Capability
+depthTest =
+    DepthTest
+
+
+{-| Dither color components or indices before they
+are written to the color buffer.
+-}
+dither : Capability
+dither =
+    Dither
+
+
+{-| Add an offset to depth values of a polygon's fragments
+produced by rasterization.
+-}
+polygonOffsetFill : Capability
+polygonOffsetFill =
+    PolygonOffsetFill
+
+
+{-| Compute a temporary coverage value
+where each bit is determined by the alpha value at the corresponding sample location.
+The temporary coverage value is then ANDed with the fragment coverage value.
+-}
+sampleAlphaToCoverage : Capability
+sampleAlphaToCoverage =
+    SampleAlphaToCoverage
+
+
+{-| The fragment's coverage is ANDed with the temporary coverage value.
+-}
+sampleCoverage : Capability
+sampleCoverage =
+    SampleCoverage
+
+
+{-| Discard fragments that are outside the scissor rectangle.
+-}
+scissorTest : Capability
+scissorTest =
+    ScissorTest
+
+
+{-| Do stencil testing and update the stencil buffer.
+-}
+stencilTest : Capability
+stencilTest =
+    StencilTest
+
+
+{-| The `BlendOperation` allows you to define which blend operation to use.
+-}
+type alias BlendOperation =
+    Types.BlendOperation
+
+
+{-|
+-}
+zero : BlendOperation
+zero =
+    Zero
+
+
+{-|
+-}
+one : BlendOperation
+one =
+    One
+
+
+{-|
+-}
+srcColor : BlendOperation
+srcColor =
+    SrcColor
+
+
+{-|
+-}
+oneMinusSrcColor : BlendOperation
+oneMinusSrcColor =
+    OneMinusSrcColor
+
+
+{-|
+-}
+dstColor : BlendOperation
+dstColor =
+    DstColor
+
+
+{-|
+-}
+oneMinusDstColor : BlendOperation
+oneMinusDstColor =
+    OneMinusDstColor
+
+
+{-|
+-}
+srcAlpha : BlendOperation
+srcAlpha =
+    SrcAlpha
+
+
+{-|
+-}
+oneMinusSrcAlpha : BlendOperation
+oneMinusSrcAlpha =
+    OneMinusSrcAlpha
+
+
+{-|
+-}
+dstAlpha : BlendOperation
+dstAlpha =
+    DstAlpha
+
+
+{-|
+-}
+oneMinusDstAlpha : BlendOperation
+oneMinusDstAlpha =
+    OneMinusDstAlpha
+
+
+{-|
+-}
+constantColor : BlendOperation
+constantColor =
+    ConstantColor
+
+
+{-|
+-}
+oneMinusConstantColor : BlendOperation
+oneMinusConstantColor =
+    OneMinusConstantColor
+
+
+{-|
+-}
+constantAlpha : BlendOperation
+constantAlpha =
+    ConstantAlpha
+
+
+{-|
+-}
+oneMinusConstantAlpha : BlendOperation
+oneMinusConstantAlpha =
+    OneMinusConstantAlpha
+
+
+{-|
+-}
+srcAlphaSaturate : BlendOperation
+srcAlphaSaturate =
+    SrcAlphaSaturate
+
+
+{-| The `BlendMode` allows you to define which blend mode to use.
+-}
+type alias BlendMode =
+    Types.BlendMode
+
+
+{-|
+-}
+add : BlendMode
+add =
+    Add
+
+
+{-|
+-}
+subtract : BlendMode
+subtract =
+    Subtract
+
+
+{-|
+-}
+reverseSubtract : BlendMode
+reverseSubtract =
+    ReverseSubtract
+
+
+{-| The `CompareMode` allows you to define how to compare values.
+-}
+type alias CompareMode =
+    Types.CompareMode
+
+
+{-|
+-}
+never : CompareMode
+never =
+    Never
+
+
+{-|
+-}
+always : CompareMode
+always =
+    Always
+
+
+{-|
+-}
+less : CompareMode
+less =
+    Less
+
+
+{-|
+-}
+lessOrEqual : CompareMode
+lessOrEqual =
+    LessOrEqual
+
+
+{-|
+-}
+equal : CompareMode
+equal =
+    Equal
+
+
+{-|
+-}
+greaterOrEqual : CompareMode
+greaterOrEqual =
+    GreaterOrEqual
+
+
+{-|
+-}
+greater : CompareMode
+greater =
+    Greater
+
+
+{-|
+-}
+notEqual : CompareMode
+notEqual =
+    NotEqual
+
+
+{-| The `FaceMode` defines which face of the stencil state is updated.
+-}
+type alias FaceMode =
+    Types.FaceMode
+
+
+{-|
+-}
+front : FaceMode
+front =
+    Front
+
+
+{-|
+-}
+back : FaceMode
+back =
+    Back
+
+
+{-|
+-}
+frontAndBack : FaceMode
+frontAndBack =
+    FrontAndBack
+
+
+{-| The `ZMode` type allows you to define what to do
+with the stencil buffer value.
+-}
+type alias ZMode =
+    Types.ZMode
+
+
+{-| Keeps the current value
+-}
+keep : ZMode
+keep =
+    Keep
+
+
+{-| Sets the stencil buffer value to 0
+-}
+none : ZMode
+none =
+    None
+
+
+{-| Sets the stencil buffer value to `ref`,
+see `Settings.stencilFunc` for more information.
+-}
+replace : ZMode
+replace =
+    Replace
+
+
+{-| Increments the current stencil buffer value.
+Clamps to the maximum representable unsigned value.
+-}
+increment : ZMode
+increment =
+    Increment
+
+
+{-| Decrements the current stencil buffer value. Clamps to 0.
+-}
+decrement : ZMode
+decrement =
+    Decrement
+
+
+{-| Bitwise inverts the current stencil buffer value.
+-}
+invert : ZMode
+invert =
+    Invert
+
+
+{-| Increments the current stencil buffer value.
+Wraps stencil buffer value to zero when incrementing
+the maximum representable unsigned value.
+-}
+incrementWrap : ZMode
+incrementWrap =
+    IncrementWrap
+
+
+{-| Decrements the current stencil buffer value.
+Wraps stencil buffer value to the maximum representable unsigned
+value when decrementing a stencil buffer value of zero.
+-}
+decrementWrap : ZMode
+decrementWrap =
+    DecrementWrap

--- a/src/WebGL/Settings.elm
+++ b/src/WebGL/Settings.elm
@@ -1,0 +1,229 @@
+module WebGL.Settings
+    exposing
+        ( Setting
+        , enable
+        , disable
+        , blendColor
+        , blendEquation
+        , blendEquationSeparate
+        , blendFunc
+        , clearColor
+        , depthFunc
+        , depthMask
+        , sampleCoverageFunc
+        , stencilFunc
+        , stencilFuncSeparate
+        , stencilOperation
+        , stencilOperationSeparate
+        , stencilMask
+        , colorMask
+        , scissor
+        )
+
+{-| The `WebGL.Setting` provides a typesafe way to call
+all pre-fragment operations and some special functions.
+
+# Settings
+@docs Setting, enable, disable, blendColor, blendEquation, blendEquationSeparate, blendFunc, clearColor, depthFunc, depthMask, sampleCoverageFunc, stencilFunc, stencilFuncSeparate, stencilOperation, stencilOperationSeparate, stencilMask, colorMask, scissor
+
+-}
+
+import WebGL.Types as Types exposing (..)
+
+
+{-| To initiate a `Setting` please use one of the following functions
+-}
+type alias Setting =
+    Types.Setting
+
+
+{-| `enable capability`
+enable server-side GL capabilities
+-}
+enable : Capability -> Setting
+enable =
+    Enable
+
+
+{-| `disable capability`
+disable server-side GL capabilities
+-}
+disable : Capability -> Setting
+disable =
+    Disable
+
+
+{-| `blendColor red green blue alpha`
+set the blend color
+-}
+blendColor : Float -> Float -> Float -> Float -> Setting
+blendColor =
+    BlendColor
+
+
+{-| `blendEquation mode`
+specify the equation used for both the
+RGB blend equation and the Alpha blend equation
+
++ `mode`: specifies how source and destination colors are combined
+-}
+blendEquation : BlendMode -> Setting
+blendEquation =
+    BlendEquation
+
+
+{-| `blendEquationSeparate modeRGB modeAlpha`
+set the RGB blend equation and the alpha blend equation separately
+
++ `modeRGB`: specifies the RGB blend equation, how the red, green,
+and blue components of the source and destination colors are combined
++ `modeAlpha`: specifies the alpha blend equation, how the alpha component
+of the source and destination colors are combined
+-}
+blendEquationSeparate : BlendMode -> BlendMode -> Setting
+blendEquationSeparate =
+    BlendEquationSeparate
+
+
+{-| `blendFunc srcFactor dstFactor`
+specify pixel arithmetic
+
++ `srcFactor`: Specifies how the red, green, blue,
+and alpha source blending factors are computed
++ `dstFactor`: Specifies how the red, green, blue,
+and alpha destination blending factors are computed
+
+`SrcAlphaSaturate` should only be used for the srcFactor.
+
+Both values may not reference a `ConstantColor` value.
+-}
+blendFunc : BlendOperation -> BlendOperation -> Setting
+blendFunc =
+    BlendFunc
+
+
+{-| `clearColor red green blue alpha`
+set the clear/background color
+-}
+clearColor : Float -> Float -> Float -> Float -> Setting
+clearColor =
+    ClearColor
+
+
+{-| `depthFunc func`
+specify the value used for depth buffer comparisons
+
++ `func`: Specifies the depth comparison function
+-}
+depthFunc : CompareMode -> Setting
+depthFunc =
+    DepthFunc
+
+
+{-| `depthMask mask`
+set the mask for the depth buffer. Any value drawn to the
+depth buffer will be ANDed with the mask. Usually used to
+turn drawing to the depth buffer on or off.
+-}
+depthMask : Int -> Setting
+depthMask =
+    DepthMask
+
+
+{-| `sampleCoverageFunc value invert`
+specify multisample coverage parameters
+
++ `value`: Specify a single floating-point sample coverage value.
+The value is clamped to the range 0 1. The initial value is `1`
++ `invert`: Specify a single boolean value representing
+if the coverage masks should be inverted. The initial value is `False`
+-}
+sampleCoverageFunc : Float -> Bool -> Setting
+sampleCoverageFunc =
+    SampleCoverageFunc
+
+
+{-| `stencilFunc func ref mask`
+set front and back function and reference value for stencil testing
+
++ `func`: Specifies the test function.  The initial value is `Always`
++ `ref`: Specifies the reference value for the stencil test. ref is
+clamped to the range 0 2 n - 1 , n is the number of bitplanes
+in the stencil buffer. The initial value is `0`.
++ `mask`: Specifies a mask that is ANDed with both the reference value
+and the stored stencil value when the test is done.
+The initial value is all `1`'s.
+-}
+stencilFunc : CompareMode -> Int -> Int -> Setting
+stencilFunc =
+    StencilFunc
+
+
+{-| `stencilFuncSeparate face func ref mask`
+set front and/or back function and reference value for stencil testing
+
++ `face`: Specifies whether front and/or back stencil state is updated
+
+See the description of `stencilFunc` for info about the other parameters
+-}
+stencilFuncSeparate : FaceMode -> CompareMode -> Int -> Int -> Setting
+stencilFuncSeparate =
+    StencilFuncSeparate
+
+
+{-| `stencilOperation fail zfail pass`
+set front and back stencil test actions
+
++ `fail`: Specifies the action to take when the stencil test fails.
+The initial value is `Keep`
++ `zfail`: Specifies the stencil action when the stencil test passes,
+but the depth test fails. The initial value is `Keep`
++ `pass`: Specifies the stencil action when both the stencil test
+and the depth test pass, or when the stencil test passes and either
+there is no depth buffer or depth testing is not enabled.
+The initial value is `Keep`
+-}
+stencilOperation : ZMode -> ZMode -> ZMode -> Setting
+stencilOperation =
+    StencilOperation
+
+
+{-| stencilOperationSeparate face fail zfail pass`
+set front and/or back stencil test actions
+
++ `face`: Specifies whether front and/or back stencil state is updated.
+
+See the description of `StencilOperation` for info about the other parameters.
+-}
+stencilOperationSeparate : FaceMode -> ZMode -> ZMode -> ZMode -> Setting
+stencilOperationSeparate =
+    StencilOperationSeparate
+
+
+{-| `stencilMask mask`
+set the stencil `mask`. This value is ANDed with anything drawn to the
+stencil buffer. Usually used to turn writing to the stencil buffer
+on or off.
+-}
+stencilMask : Int -> Setting
+stencilMask =
+    StencilMask
+
+
+{-| `colorMask red green blue alpha`
+set mask to be applied to anything drawn to the color buffer.
+Values drawn to each channel will be ANDed with their
+color mask respectively.
+-}
+colorMask : Int -> Int -> Int -> Int -> Setting
+colorMask =
+    ColorMask
+
+
+{-| `scissor x y width height`
+set the scissor box, which limits the drawing of fragments to the
+screen to a specified rectangle.
+-}
+scissor : Int -> Int -> Int -> Int -> Setting
+scissor =
+    Scissor

--- a/src/WebGL/Types.elm
+++ b/src/WebGL/Types.elm
@@ -1,0 +1,380 @@
+module WebGL.Types
+    exposing
+        ( Setting(..)
+        , Capability(..)
+        , BlendOperation(..)
+        , BlendMode(..)
+        , CompareMode(..)
+        , FaceMode(..)
+        , ZMode(..)
+        , Drawable(..)
+        , computeAPICall
+        )
+
+import Native.Settings
+
+
+type Drawable attributes
+    = Triangles (List ( attributes, attributes, attributes ))
+    | Lines (List ( attributes, attributes ))
+    | LineStrip (List attributes)
+    | LineLoop (List attributes)
+    | Points (List attributes)
+    | TriangleFan (List attributes)
+    | TriangleStrip (List attributes)
+    | IndexedTriangles (List attributes) (List ( Int, Int, Int ))
+
+
+type Setting
+    = Enable Capability
+    | Disable Capability
+    | BlendColor Float Float Float Float
+    | BlendEquation BlendMode
+    | BlendEquationSeparate BlendMode BlendMode
+    | BlendFunc BlendOperation BlendOperation
+    | ClearColor Float Float Float Float
+    | DepthFunc CompareMode
+    | DepthMask Int
+    | SampleCoverageFunc Float Bool
+    | StencilFunc CompareMode Int Int
+    | StencilFuncSeparate FaceMode CompareMode Int Int
+    | StencilOperation ZMode ZMode ZMode
+    | StencilOperationSeparate FaceMode ZMode ZMode ZMode
+    | StencilMask Int
+    | ColorMask Int Int Int Int
+    | Scissor Int Int Int Int
+
+
+computeCapabilityString : Capability -> String
+computeCapabilityString capability =
+    case capability of
+        Blend ->
+            "BLEND"
+
+        CullFace ->
+            "CULL_FACE"
+
+        DepthTest ->
+            "DEPTH_TEST"
+
+        Dither ->
+            "DITHER"
+
+        PolygonOffsetFill ->
+            "POLYGON_OFFSET_FILL"
+
+        SampleAlphaToCoverage ->
+            "SAMPLE_ALPHA_TO_COVERAGE"
+
+        SampleCoverage ->
+            "SAMPLE_COVERAGE"
+
+        ScissorTest ->
+            "SCISSOR_TEST"
+
+        StencilTest ->
+            "STENCIL_TEST"
+
+
+type Capability
+    = Blend
+    | CullFace
+    | DepthTest
+    | Dither
+    | PolygonOffsetFill
+    | SampleAlphaToCoverage
+    | SampleCoverage
+    | ScissorTest
+    | StencilTest
+
+
+computeBlendOperationString : BlendOperation -> String
+computeBlendOperationString operation =
+    case operation of
+        Zero ->
+            "ZERO"
+
+        One ->
+            "ONE"
+
+        SrcColor ->
+            "SRC_COLOR"
+
+        OneMinusSrcColor ->
+            "ONE_MINUS_SRC_COLOR"
+
+        DstColor ->
+            "DST_COLOR"
+
+        OneMinusDstColor ->
+            "ONE_MINUS_DST_COLOR"
+
+        SrcAlpha ->
+            "SRC_ALPHA"
+
+        OneMinusSrcAlpha ->
+            "ONE_MINUS_SRC_ALPHA"
+
+        DstAlpha ->
+            "DST_ALPHA"
+
+        OneMinusDstAlpha ->
+            "ONE_MINUS_DST_ALPHA"
+
+        ConstantColor ->
+            "CONSTANT_COLOR"
+
+        OneMinusConstantColor ->
+            "ONE_MINUS_CONSTANT_COLOR"
+
+        ConstantAlpha ->
+            "CONSTANT_ALPHA"
+
+        OneMinusConstantAlpha ->
+            "ONE_MINUS_CONSTANT_ALPHA"
+
+        SrcAlphaSaturate ->
+            "SRC_ALPHA_SATURATE"
+
+
+{-| The `BlendOperation` type allows you to define which blend operation to use.
+-}
+type BlendOperation
+    = Zero
+    | One
+    | SrcColor
+    | OneMinusSrcColor
+    | DstColor
+    | OneMinusDstColor
+    | SrcAlpha
+    | OneMinusSrcAlpha
+    | DstAlpha
+    | OneMinusDstAlpha
+    | ConstantColor
+    | OneMinusConstantColor
+    | ConstantAlpha
+    | OneMinusConstantAlpha
+    | SrcAlphaSaturate
+
+
+computeBlendModeString : BlendMode -> String
+computeBlendModeString mode =
+    case mode of
+        Add ->
+            "FUNC_ADD"
+
+        Subtract ->
+            "FUNC_SUBTRACT"
+
+        ReverseSubtract ->
+            "FUNC_REVERSE_SUBTRACT"
+
+
+type BlendMode
+    = Add
+    | Subtract
+    | ReverseSubtract
+
+
+computeCompareModeString : CompareMode -> String
+computeCompareModeString mode =
+    case mode of
+        Never ->
+            "NEVER"
+
+        Always ->
+            "ALWAYS"
+
+        Less ->
+            "LESS"
+
+        LessOrEqual ->
+            "LEQUAL"
+
+        Equal ->
+            "EQUAL"
+
+        GreaterOrEqual ->
+            "GEQUAL"
+
+        Greater ->
+            "GREATER"
+
+        NotEqual ->
+            "NOTEQUAL"
+
+
+type CompareMode
+    = Never
+    | Always
+    | Less
+    | LessOrEqual
+    | Equal
+    | GreaterOrEqual
+    | Greater
+    | NotEqual
+
+
+computeFaceModeString : FaceMode -> String
+computeFaceModeString mode =
+    case mode of
+        Front ->
+            "FRONT"
+
+        Back ->
+            "BACK"
+
+        FrontAndBack ->
+            "FRONT_AND_BACK"
+
+
+type FaceMode
+    = Front
+    | Back
+    | FrontAndBack
+
+
+computeZModeString : ZMode -> String
+computeZModeString mode =
+    case mode of
+        Keep ->
+            "KEEP"
+
+        None ->
+            "ZERO"
+
+        Replace ->
+            "REPLACE"
+
+        Increment ->
+            "INCREMENT"
+
+        Decrement ->
+            "DECREMENT"
+
+        Invert ->
+            "INVERT"
+
+        IncrementWrap ->
+            "INCREMENT_WRAP"
+
+        DecrementWrap ->
+            "DECREMENT_WRAP"
+
+
+type ZMode
+    = Keep
+    | None
+    | Replace
+    | Increment
+    | Decrement
+    | Invert
+    | IncrementWrap
+    | DecrementWrap
+
+
+computeAPICall : Setting -> (a -> b)
+computeAPICall setting =
+    case setting of
+        Enable capability ->
+            computeCapabilityString capability
+                |> Native.Settings.enable
+
+        Disable capability ->
+            computeCapabilityString capability
+                |> Native.Settings.disable
+
+        BlendColor r g b a ->
+            Native.Settings.blendColor r g b a
+
+        BlendEquation mode ->
+            computeBlendModeString mode
+                |> Native.Settings.blendEquation
+
+        BlendEquationSeparate modeRGB_ modeAlpha_ ->
+            let
+                modeRGB =
+                    computeBlendModeString modeRGB_
+
+                modeAlpha =
+                    computeBlendModeString modeAlpha_
+            in
+                Native.Settings.blendEquationSeparate modeRGB modeAlpha
+
+        BlendFunc src_ dst_ ->
+            let
+                src =
+                    computeBlendOperationString src_
+
+                dst =
+                    computeBlendOperationString dst_
+            in
+                Native.Settings.blendFunc src dst
+
+        ClearColor r g b a ->
+            Native.Settings.clearColor r g b a
+
+        DepthFunc mode ->
+            computeCompareModeString mode
+                |> Native.Settings.depthFunc
+
+        DepthMask mask ->
+            Native.Settings.depthMask mask
+
+        SampleCoverageFunc value invert ->
+            Native.Settings.sampleCoverage value invert
+
+        StencilFunc func ref mask ->
+            let
+                mode =
+                    computeCompareModeString func
+            in
+                Native.Settings.stencilFunc mode ref mask
+
+        StencilFuncSeparate face_ func ref mask ->
+            let
+                face =
+                    computeFaceModeString face_
+
+                mode =
+                    computeCompareModeString func
+            in
+                Native.Settings.stencilFuncSeparate face mode ref mask
+
+        StencilOperation fail_ zfail_ zpass_ ->
+            let
+                fail =
+                    computeZModeString fail_
+
+                zfail =
+                    computeZModeString zfail_
+
+                zpass =
+                    computeZModeString zpass_
+            in
+                Native.Settings.stencilOperation fail zfail zpass
+
+        StencilOperationSeparate face_ fail_ zfail_ zpass_ ->
+            let
+                face =
+                    computeFaceModeString face_
+
+                fail =
+                    computeZModeString fail_
+
+                zfail =
+                    computeZModeString zfail_
+
+                zpass =
+                    computeZModeString zpass_
+            in
+                Native.Settings.stencilOperationSeparate face fail zfail zpass
+
+        StencilMask mask ->
+            Native.Settings.stencilMask mask
+
+        ColorMask r g b a ->
+            Native.Settings.colorMask r g b a
+
+        Scissor x y w h ->
+            Native.Settings.scissor x y w h


### PR DESCRIPTION
As discussed with Evan, type constructors should not be exported, because we don't want people to pattern match these structures, and we may need to extend the union types without breaking changes.

Because this exploded with many functions, I split them into `Settings` and `Constants`. Maybe this was not entirely a nice idea, we can always put it back, because this is WIP.