### PR TITLE
Unify custom options

### DIFF
--- a/examples/first-person.elm
+++ b/examples/first-person.elm
@@ -278,10 +278,12 @@ view { size, person, texture } =
                 , ( "position", "relative" )
                 ]
             ]
-            [ WebGL.toHtmlWithEvenMore
-                { defaultContextAttributes | alpha = False }
-                defaultConfiguration
-                [ width size.width, height size.height, style [ ( "display", "block" ) ] ]
+            [ WebGL.toHtmlWith
+                { defaultOptions | alpha = False }
+                [ width size.width
+                , height size.height
+                , style [ ( "display", "block" ) ]
+                ]
                 entities
             , div
                 [ style

--- a/examples/triangle.elm
+++ b/examples/triangle.elm
@@ -4,7 +4,6 @@ import Math.Vector3 exposing (..)
 import Math.Matrix4 exposing (..)
 import WebGL exposing (..)
 import WebGL.Settings as Settings
-import WebGL.Constants as Constants
 import Html exposing (Html)
 import Html.Attributes exposing (width, height)
 import AnimationFrame
@@ -41,9 +40,9 @@ main =
 view : Float -> Html msg
 view t =
     WebGL.toHtmlWith
-        [ Settings.enable Constants.depthTest
-        , Settings.clearColor 0 0 0 1
-        ]
+        { defaultOptions
+            | settings = Settings.clearColor 0 0 0 1 :: defaultOptions.settings
+        }
         [ width 400, height 400 ]
         [ render vertexShader fragmentShader mesh { perspective = perspective (t / 1000) } ]
 

--- a/src/Native/WebGL.js
+++ b/src/Native/WebGL.js
@@ -472,12 +472,19 @@ var _elm_community$webgl$Native_WebGL = function () {
 
   // VIRTUAL-DOM WIDGET
 
-  function toHtml(contextAttributes, functionCalls, factList, renderables) {
+  function toHtml(options, functionCalls, factList, renderables) {
     var model = {
       functionCalls: functionCalls,
       renderables: renderables,
       cache: {},
-      contextAttributes: contextAttributes
+      // filter out context attributes from options 
+      contextAttributes: {
+        alpha: options.alpha,
+        depth: options.depth,
+        stencil: options.stencil,
+        antialias: options.antialias,
+        premultipliedAlpha: options.premultipliedAlpha
+      }
     };
     // eslint-disable-next-line camelcase
     return _elm_lang$virtual_dom$Native_VirtualDom.custom(factList, model, implementation);


### PR DESCRIPTION
The idea is to only have one set of `Options`, that include `settings` and attributes for the WebGL context. This makes api simpler then having additional `toHtmlWithEvenMore`.