### PR TITLE
Grouping WebGL settings

### DIFF
--- a/examples/crate.elm
+++ b/examples/crate.elm
@@ -175,23 +175,19 @@ view { texture, theta } =
                     perspective theta
             in
                 [ renderBox
-                    [ disable stencilTest ]
+                    [ depth depthOptions ]
                     Math.Matrix4.identity
                     (vec3 1 1 1)
                     tex
                     camera
                 , renderFloor
-                    [ enable stencilTest
-                    , stencilFunc WebGL.Constants.always 1 255
-                    , stencilOperation keep keep replace
-                    , stencilMask 1
-                    , depthMask False
+                    [ depth { depthOptions | mask = False }
+                    , stencil { stencilOptions | ref = 1, zpass = replace }
                     ]
                     camera
                 , renderBox
-                    [ stencilFunc equal 1 255
-                    , stencilMask 0
-                    , depthMask True
+                    [ stencil { stencilOptions | func = equal, ref = 1, writeMask = 0 }
+                    , depth depthOptions
                     ]
                     (makeScale (vec3 1 -1 1))
                     (vec3 0.6 0.6 0.6)

--- a/examples/triangle.elm
+++ b/examples/triangle.elm
@@ -3,7 +3,6 @@ module Main exposing (..)
 import Math.Vector3 exposing (..)
 import Math.Matrix4 exposing (..)
 import WebGL exposing (..)
-import WebGL.Settings as Settings
 import Html exposing (Html)
 import Html.Attributes exposing (width, height)
 import AnimationFrame
@@ -41,13 +40,7 @@ view : Float -> Html msg
 view t =
     WebGL.toHtml
         [ width 400, height 400 ]
-        [ renderWithSettings
-            [ Settings.clearColor 0 0 0 1 ]
-            vertexShader
-            fragmentShader
-            mesh
-            { perspective = perspective (t / 1000) }
-        ]
+        [ render vertexShader fragmentShader mesh { perspective = perspective (t / 1000) } ]
 
 
 perspective : Float -> Mat4

--- a/examples/triangle.elm
+++ b/examples/triangle.elm
@@ -39,12 +39,15 @@ main =
 
 view : Float -> Html msg
 view t =
-    WebGL.toHtmlWith
-        { defaultOptions
-            | settings = Settings.clearColor 0 0 0 1 :: defaultOptions.settings
-        }
+    WebGL.toHtml
         [ width 400, height 400 ]
-        [ render vertexShader fragmentShader mesh { perspective = perspective (t / 1000) } ]
+        [ renderWithSettings
+            [ Settings.clearColor 0 0 0 1 ]
+            vertexShader
+            fragmentShader
+            mesh
+            { perspective = perspective (t / 1000) }
+        ]
 
 
 perspective : Float -> Mat4

--- a/src/Native/WebGL.js
+++ b/src/Native/WebGL.js
@@ -124,9 +124,6 @@ var _elm_community$webgl$Native_WebGL = function () {
         case 'SampleCoverage':
           gl.sampleCoverage(setting._0, setting._1);
           break;
-        case 'ClearColor':
-          gl.clearColor(setting._0, setting._1, setting._2, setting._3);
-          break;
         case 'Enable':
           cleanupOperations.push(disable(setting._0));
           gl.enable(setting._0);

--- a/src/Native/WebGL.js
+++ b/src/Native/WebGL.js
@@ -121,6 +121,20 @@ var _elm_community$webgl$Native_WebGL = function () {
           });
           gl.colorMask(setting._0, setting._1, setting._2, setting._3);
           break;
+        case 'CullFace':
+          cleanupOperations.push(disable(gl.CULL_FACE));
+          gl.enable(gl.CULL_FACE);
+          gl.cullFace(s1);
+          break;
+        case 'Dither':
+          cleanupOperations.push(disable(gl.DITHER));
+          gl.enable(gl.DITHER);
+          break;
+        case 'PolygonOffset':
+          cleanupOperations.push(disable(gl.POLYGON_OFFSET_FILL));
+          gl.enable(gl.POLYGON_OFFSET_FILL);
+          gl.polygonOffset(s1, s2);
+          break;
         case 'SampleCoverage':
           gl.sampleCoverage(setting._0, setting._1);
           break;

--- a/src/Native/WebGL.js
+++ b/src/Native/WebGL.js
@@ -136,11 +136,13 @@ var _elm_community$webgl$Native_WebGL = function () {
           gl.polygonOffset(s1, s2);
           break;
         case 'SampleCoverage':
-          gl.sampleCoverage(setting._0, setting._1);
+          cleanupOperations.push(disable(gl.SAMPLE_COVERAGE));
+          gl.enable(gl.SAMPLE_COVERAGE);
+          gl.sampleCoverage(s1, s2);
           break;
-        case 'Enable':
-          cleanupOperations.push(disable(setting._0));
-          gl.enable(setting._0);
+        case 'SampleAlphaToCoverage':
+          cleanupOperations.push(disable(gl.SAMPLE_ALPHA_TO_COVERAGE));
+          gl.enable(gl.SAMPLE_ALPHA_TO_COVERAGE);
           break;
       }
     }, settings);

--- a/src/Native/WebGL.js
+++ b/src/Native/WebGL.js
@@ -51,8 +51,16 @@ var _elm_community$webgl$Native_WebGL = function () {
 
   }
 
+ /**
+  *  Apply settings to the gl context
+  *
+  *  @param {WebGLRenderingContext} gl context
+  *  @param {List} settings the list of settings coming in from Elm
+  *  @return {Array<GLenum>} the list of enabled capabilities, caused by
+  *          applying the settings
+  */
   function doSettings(gl, settings) {
-    var disable = [];
+    var enabledCapabilities = [];
     var s1;
     var s2;
     listEach(function (setting) {
@@ -60,35 +68,35 @@ var _elm_community$webgl$Native_WebGL = function () {
       s2 = setting._1;
       switch (setting.ctor) {
         case 'Blend':
-          disable.push(gl.BLEND);
+          enabledCapabilities.push(gl.BLEND);
           gl.enable(gl.BLEND);
           gl.blendColor(setting._1, setting._2, setting._3, setting._4);
           gl.blendFunc(s1.source._0, s1.destination._0);
           gl.blendEquation(s1.equation._0);
           break;
         case 'BlendSeparate':
-          disable.push(gl.BLEND);
+          enabledCapabilities.push(gl.BLEND);
           gl.enable(gl.BLEND);
           gl.blendColor(setting._2, setting._3, setting._4, setting._5);
           gl.blendFuncSeparate(s1.source._0, s1.destination._0, s2.source._0, s2.destination._0);
           gl.blendEquationSeparate(s1.equation._0, s2.equation._0);
           break;
         case 'Depth':
-          disable.push(gl.DEPTH_TEST);
+          enabledCapabilities.push(gl.DEPTH_TEST);
           gl.enable(gl.DEPTH_TEST);
           gl.depthFunc(s1.func._0);
           gl.depthMask(s1.mask);
           gl.depthRange(s1.near, s1.far);
           break;
         case 'Stencil':
-          disable.push(gl.STENCIL_TEST);
+          enabledCapabilities.push(gl.STENCIL_TEST);
           gl.enable(gl.STENCIL_TEST);
           gl.stencilFunc(s1.func._0, s1.ref, s1.valueMask);
           gl.stencilOp(s1.fail._0, s1.zfail._0, s1.zpass._0);
           gl.stencilMask(s1.writeMask);
           break;
         case 'StencilFuncSeparate':
-          disable.push(gl.STENCIL_TEST);
+          enabledCapabilities.push(gl.STENCIL_TEST);
           gl.enable(gl.STENCIL_TEST);
           gl.stencilFuncSeparate(gl.FRONT, s1.func._0, s1.ref, s1.valueMask);
           gl.stencilOpSeparate(gl.FRONT, s1.fail._0, s1.zfail._0, s1.zpass._0);
@@ -110,12 +118,12 @@ var _elm_community$webgl$Native_WebGL = function () {
           gl.clearColor(setting._0, setting._1, setting._2, setting._3);
           break;
         case 'Enable':
-          disable.push(setting._0);
+          enabledCapabilities.push(setting._0);
           gl.enable(setting._0);
           break;
       }
     }, settings);
-    return disable;
+    return enabledCapabilities;
   }
 
 
@@ -447,11 +455,11 @@ var _elm_community$webgl$Native_WebGL = function () {
         gl.vertexAttribPointer(attribLocation, attributeInfo.size, attributeInfo.baseType, false, 0, 0);
       }
 
-      var disable = doSettings(gl, render.settings);
+      var enabledCapabilities = doSettings(gl, render.settings);
 
       gl.drawElements(renderType.mode, buffer.numIndices, gl.UNSIGNED_SHORT, 0);
 
-      disable.forEach(function (capability) {
+      enabledCapabilities.forEach(function (capability) {
         gl.disable(capability);
       });
 

--- a/src/WebGL.elm
+++ b/src/WebGL.elm
@@ -46,7 +46,6 @@ documentation provided here.
 
 import Html exposing (Html, Attribute)
 import WebGL.Settings as Settings exposing (Setting)
-import WebGL.Constants as Constants
 import Native.WebGL
 
 
@@ -182,7 +181,7 @@ custom per-render configurations.
 -}
 render : Shader attributes uniforms varyings -> Shader {} uniforms varyings -> Drawable attributes -> uniforms -> Renderable
 render =
-    renderWithSettings []
+    renderWithSettings [ Settings.depth Settings.depthOptions ]
 
 
 {-| Same as toHtmlWith but with default configurations,
@@ -208,7 +207,6 @@ type alias Options =
     , stencil : Bool
     , antialias : Bool
     , premultipliedAlpha : Bool
-    , settings : List Setting
     }
 
 
@@ -223,7 +221,6 @@ defaultOptions =
     , stencil = False
     , antialias = True
     , premultipliedAlpha = True
-    , settings = [ Settings.enable Constants.depthTest ]
     }
 
 
@@ -232,5 +229,5 @@ Shaders and meshes are cached so that they do not get resent to the GPU,
 so it should be relatively cheap to create new entities out of existing values.
 -}
 toHtmlWith : Options -> List (Attribute msg) -> List Renderable -> Html msg
-toHtmlWith ({ settings } as options) =
-    Native.WebGL.toHtml options settings
+toHtmlWith options attributes renderables =
+    Native.WebGL.toHtml options attributes renderables

--- a/src/WebGL/Constants.elm
+++ b/src/WebGL/Constants.elm
@@ -3,23 +3,19 @@ module WebGL.Constants exposing (..)
 {-|
 # Capabilities
 
-@docs Capability, blend, cullFace, depthTest, dither, polygonOffsetFill, sampleAlphaToCoverage, sampleCoverage, scissorTest, stencilTest
+@docs Capability, cullFace, dither, polygonOffsetFill, sampleAlphaToCoverage, sampleCoverage, scissorTest
 
-# Blend Operations
+# Blend Factors
 
-@docs BlendOperation, zero, one, srcColor, oneMinusSrcColor, dstColor, oneMinusDstColor, srcAlpha, oneMinusSrcAlpha, dstAlpha, oneMinusDstAlpha, constantColor, oneMinusConstantColor, constantAlpha, oneMinusConstantAlpha, srcAlphaSaturate
+@docs BlendFactor, zero, one, srcColor, oneMinusSrcColor, dstColor, oneMinusDstColor, srcAlpha, oneMinusSrcAlpha, dstAlpha, oneMinusDstAlpha, constantColor, oneMinusConstantColor, constantAlpha, oneMinusConstantAlpha, srcAlphaSaturate
 
-# Blend Modes
+# Blend Equations
 
-@docs BlendMode, add, subtract, reverseSubtract
+@docs BlendEquation, add, subtract, reverseSubtract
 
 # Compare Modes
 
 @docs CompareMode, never, always, less, lessOrEqual, equal, greaterOrEqual, greater, notEqual
-
-# Face Modes
-
-@docs FaceMode, front, back, frontAndBack
 
 # ZModes
 
@@ -34,26 +30,11 @@ type Capability
     = Capability Int
 
 
-{-| Blend the computed fragment color values
-with the values in the color buffers.
--}
-blend : Capability
-blend =
-    Capability 3042
-
-
 {-| Cull polygons based on their winding in window coordinates.
 -}
 cullFace : Capability
 cullFace =
     Capability 2884
-
-
-{-| Do depth comparisons and update the depth buffer.
--}
-depthTest : Capability
-depthTest =
-    Capability 2929
 
 
 {-| Dither color components or indices before they
@@ -95,149 +76,142 @@ scissorTest =
     Capability 3089
 
 
-{-| Do stencil testing and update the stencil buffer.
+{-| Allows you to define which blend factor to use.
 -}
-stencilTest : Capability
-stencilTest =
-    Capability 2960
-
-
-{-| The `BlendOperation` allows you to define which blend operation to use.
--}
-type BlendOperation
-    = BlendOperation Int
+type BlendFactor
+    = BlendFactor Int
 
 
 {-|
 -}
-zero : BlendOperation
+zero : BlendFactor
 zero =
-    BlendOperation 0
+    BlendFactor 0
 
 
 {-|
 -}
-one : BlendOperation
+one : BlendFactor
 one =
-    BlendOperation 1
+    BlendFactor 1
 
 
 {-|
 -}
-srcColor : BlendOperation
+srcColor : BlendFactor
 srcColor =
-    BlendOperation 768
+    BlendFactor 768
 
 
 {-|
 -}
-oneMinusSrcColor : BlendOperation
+oneMinusSrcColor : BlendFactor
 oneMinusSrcColor =
-    BlendOperation 769
+    BlendFactor 769
 
 
 {-|
 -}
-dstColor : BlendOperation
+dstColor : BlendFactor
 dstColor =
-    BlendOperation 774
+    BlendFactor 774
 
 
 {-|
 -}
-oneMinusDstColor : BlendOperation
+oneMinusDstColor : BlendFactor
 oneMinusDstColor =
-    BlendOperation 775
+    BlendFactor 775
 
 
 {-|
 -}
-srcAlpha : BlendOperation
+srcAlpha : BlendFactor
 srcAlpha =
-    BlendOperation 770
+    BlendFactor 770
 
 
 {-|
 -}
-oneMinusSrcAlpha : BlendOperation
+oneMinusSrcAlpha : BlendFactor
 oneMinusSrcAlpha =
-    BlendOperation 771
+    BlendFactor 771
 
 
 {-|
 -}
-dstAlpha : BlendOperation
+dstAlpha : BlendFactor
 dstAlpha =
-    BlendOperation 772
+    BlendFactor 772
 
 
 {-|
 -}
-oneMinusDstAlpha : BlendOperation
+oneMinusDstAlpha : BlendFactor
 oneMinusDstAlpha =
-    BlendOperation 773
+    BlendFactor 773
 
 
 {-|
 -}
-constantColor : BlendOperation
+constantColor : BlendFactor
 constantColor =
-    BlendOperation 32769
+    BlendFactor 32769
 
 
 {-|
 -}
-oneMinusConstantColor : BlendOperation
+oneMinusConstantColor : BlendFactor
 oneMinusConstantColor =
-    BlendOperation 32770
+    BlendFactor 32770
 
 
 {-|
 -}
-constantAlpha : BlendOperation
+constantAlpha : BlendFactor
 constantAlpha =
-    BlendOperation 32771
+    BlendFactor 32771
 
 
 {-|
 -}
-oneMinusConstantAlpha : BlendOperation
+oneMinusConstantAlpha : BlendFactor
 oneMinusConstantAlpha =
-    BlendOperation 32772
+    BlendFactor 32772
 
 
 {-|
 -}
-srcAlphaSaturate : BlendOperation
+srcAlphaSaturate : BlendFactor
 srcAlphaSaturate =
-    BlendOperation 776
+    BlendFactor 776
 
 
-{-| The `BlendMode` allows you to define which blend mode to use.
+{-| The `BlendEquation` allows you to define which blend mode to use.
 -}
-type BlendMode
-    = BlendMode Int
+type BlendEquation
+    = BlendEquation Int
 
 
 {-|
 -}
-add : BlendMode
+add : BlendEquation
 add =
-    BlendMode 32774
+    BlendEquation 32774
 
 
 {-|
 -}
-subtract : BlendMode
+subtract : BlendEquation
 subtract =
-    BlendMode 32778
+    BlendEquation 32778
 
 
 {-|
 -}
-reverseSubtract : BlendMode
+reverseSubtract : BlendEquation
 reverseSubtract =
-    BlendMode 32779
+    BlendEquation 32779
 
 
 {-| The `CompareMode` allows you to define how to compare values.
@@ -300,33 +274,6 @@ greater =
 notEqual : CompareMode
 notEqual =
     CompareMode 517
-
-
-{-| The `FaceMode` defines which face of the stencil state is updated.
--}
-type FaceMode
-    = FaceMode Int
-
-
-{-|
--}
-front : FaceMode
-front =
-    FaceMode 1028
-
-
-{-|
--}
-back : FaceMode
-back =
-    FaceMode 1029
-
-
-{-|
--}
-frontAndBack : FaceMode
-frontAndBack =
-    FaceMode 1032
 
 
 {-| The `ZMode` type allows you to define what to do

--- a/src/WebGL/Constants.elm
+++ b/src/WebGL/Constants.elm
@@ -3,7 +3,7 @@ module WebGL.Constants exposing (..)
 {-|
 # Capabilities
 
-@docs Capability, cullFace, dither, polygonOffsetFill, sampleAlphaToCoverage, sampleCoverage
+@docs Capability, sampleAlphaToCoverage, sampleCoverage
 
 # Blend Factors
 
@@ -17,6 +17,10 @@ module WebGL.Constants exposing (..)
 
 @docs CompareMode, never, always, less, lessOrEqual, equal, greaterOrEqual, greater, notEqual
 
+# Face Modes
+
+@docs FaceMode, front, back, frontAndBack
+
 # ZModes
 
 @docs ZMode, keep, none, replace, increment, decrement, invert, incrementWrap, decrementWrap
@@ -28,29 +32,6 @@ server-side GL capabilities.
 -}
 type Capability
     = Capability Int
-
-
-{-| Cull polygons based on their winding in window coordinates.
--}
-cullFace : Capability
-cullFace =
-    Capability 2884
-
-
-{-| Dither color components or indices before they
-are written to the color buffer.
--}
-dither : Capability
-dither =
-    Capability 3024
-
-
-{-| Add an offset to depth values of a polygon's fragments
-produced by rasterization.
--}
-polygonOffsetFill : Capability
-polygonOffsetFill =
-    Capability 32823
 
 
 {-| Compute a temporary coverage value
@@ -267,6 +248,33 @@ greater =
 notEqual : CompareMode
 notEqual =
     CompareMode 517
+
+
+{-| The `FaceMode` defines the face of the polygon
+-}
+type FaceMode
+    = FaceMode Int
+
+
+{-| Targets the front-facing polygons
+-}
+front : FaceMode
+front =
+    FaceMode 1028
+
+
+{-| Targets the back-facing polygons
+-}
+back : FaceMode
+back =
+    FaceMode 1029
+
+
+{-| Targets both front- and back-facing polygons
+-}
+frontAndBack : FaceMode
+frontAndBack =
+    FaceMode 1032
 
 
 {-| The `ZMode` type allows you to define what to do

--- a/src/WebGL/Constants.elm
+++ b/src/WebGL/Constants.elm
@@ -1,9 +1,6 @@
 module WebGL.Constants exposing (..)
 
 {-|
-# Capabilities
-
-@docs Capability, sampleAlphaToCoverage, sampleCoverage
 
 # Blend Factors
 
@@ -25,29 +22,6 @@ module WebGL.Constants exposing (..)
 
 @docs ZMode, keep, none, replace, increment, decrement, invert, incrementWrap, decrementWrap
 -}
-
-
-{-| The `Capability` is used to enable/disable
-server-side GL capabilities.
--}
-type Capability
-    = Capability Int
-
-
-{-| Compute a temporary coverage value
-where each bit is determined by the alpha value at the corresponding sample location.
-The temporary coverage value is then ANDed with the fragment coverage value.
--}
-sampleAlphaToCoverage : Capability
-sampleAlphaToCoverage =
-    Capability 32926
-
-
-{-| The fragment's coverage is ANDed with the temporary coverage value.
--}
-sampleCoverage : Capability
-sampleCoverage =
-    Capability 32928
 
 
 {-| Allows you to define which blend factor to use.

--- a/src/WebGL/Constants.elm
+++ b/src/WebGL/Constants.elm
@@ -3,7 +3,7 @@ module WebGL.Constants exposing (..)
 {-|
 # Capabilities
 
-@docs Capability, cullFace, dither, polygonOffsetFill, sampleAlphaToCoverage, sampleCoverage, scissorTest
+@docs Capability, cullFace, dither, polygonOffsetFill, sampleAlphaToCoverage, sampleCoverage
 
 # Blend Factors
 
@@ -67,13 +67,6 @@ sampleAlphaToCoverage =
 sampleCoverage : Capability
 sampleCoverage =
     Capability 32928
-
-
-{-| Discard fragments that are outside the scissor rectangle.
--}
-scissorTest : Capability
-scissorTest =
-    Capability 3089
 
 
 {-| Allows you to define which blend factor to use.

--- a/src/WebGL/Settings.elm
+++ b/src/WebGL/Settings.elm
@@ -17,7 +17,6 @@ module WebGL.Settings
           -- todo:
         , sampleCoverageFunc
         , enable
-        , clearColor
         )
 
 {-| The `WebGL.Setting` provides a typesafe way to call
@@ -41,7 +40,7 @@ all pre-fragment operations and some special functions.
 
 # Other settings
 
-@docs scissor, colorMask, enable, clearColor, sampleCoverageFunc
+@docs scissor, colorMask, enable, sampleCoverageFunc
 
 -}
 
@@ -58,7 +57,6 @@ type Setting
     | StencilSeparate StencilOptions StencilOptions
     | Scissor Int Int Int Int
     | ColorMask Bool Bool Bool Bool
-      -- todo:
     | SampleCoverageFunc Float Bool
     | Enable Int
     | ClearColor Float Float Float Float
@@ -234,12 +232,3 @@ enable server-side GL capabilities
 enable : WebGL.Constants.Capability -> Setting
 enable (WebGL.Constants.Capability capability) =
     Enable capability
-
-
-{-| `clearColor red green blue alpha`
-set the clear/background color,
-should be set before clearing the scene
--}
-clearColor : Float -> Float -> Float -> Float -> Setting
-clearColor =
-    ClearColor

--- a/src/WebGL/Settings.elm
+++ b/src/WebGL/Settings.elm
@@ -17,9 +17,8 @@ module WebGL.Settings
         , cullFace
         , dither
         , polygonOffset
-          -- todo:
-        , sampleCoverageFunc
-        , enable
+        , sampleCoverage
+        , sampleAlphaToCoverage
         )
 
 {-| The `WebGL.Setting` provides a typesafe way to call
@@ -43,7 +42,8 @@ all pre-fragment operations and some special functions.
 
 # Other settings
 
-@docs scissor, colorMask, cullFace, dither, polygonOffset, enable, sampleCoverageFunc
+@docs scissor, colorMask, cullFace, dither, polygonOffset,
+      sampleCoverage, sampleAlphaToCoverage
 
 -}
 
@@ -63,9 +63,8 @@ type Setting
     | CullFace Int
     | Dither
     | PolygonOffset Float Float
-    | SampleCoverageFunc Float Bool
-    | Enable Int
-    | ClearColor Float Float Float Float
+    | SampleCoverage Float Bool
+    | SampleAlphaToCoverage
 
 
 {-| Blend setting allows to control how the source and destination
@@ -239,34 +238,32 @@ dither =
 produced by rasterization. The offset is added before the depth
 test is performed and before the value is written into the depth buffer.
 
-* `factor` the first argument is the scale factor for the variable depth offset for each polygon.
-* `units` the second argument is the multiplier by which an implementation-specific value is multiplied
+* the first argument is the scale factor for the variable depth offset for each polygon.
+* the second argument is the multiplier by which an implementation-specific value is multiplied
   with to create a constant depth offset.
-
 -}
 polygonOffset : Float -> Float -> Setting
 polygonOffset =
     PolygonOffset
 
 
-{-| `sampleCoverageFunc value invert`
-specify multisample coverage parameters
+{-| Specify multisample coverage parameters.
 
-Requires sampleAlphaToCoverage or sampleCoverage to be enabled.
+The fragment's coverage is ANDed with the temporary coverage value.
 
-+ `value`: Specify a single floating-point sample coverage value.
-The value is clamped to the range 0 1. The initial value is `1`
-+ `invert`: Specify a single boolean value representing
-if the coverage masks should be inverted. The initial value is `False`
+* the first argument specifies sample coverage value, that is clamped to the range 0 1.
+* the second argument represents if the coverage masks should be inverted.
 -}
-sampleCoverageFunc : Float -> Bool -> Setting
-sampleCoverageFunc =
-    SampleCoverageFunc
+sampleCoverage : Float -> Bool -> Setting
+sampleCoverage =
+    SampleCoverage
 
 
-{-| `enable capability`
-enable server-side GL capabilities
+{-| Compute a temporary coverage value
+where each bit is determined by the alpha value at the corresponding sample location.
+
+The temporary coverage value is then ANDed with the fragment coverage value.
 -}
-enable : WebGL.Constants.Capability -> Setting
-enable (WebGL.Constants.Capability capability) =
-    Enable capability
+sampleAlphaToCoverage : Setting
+sampleAlphaToCoverage =
+    SampleAlphaToCoverage

--- a/src/WebGL/Settings.elm
+++ b/src/WebGL/Settings.elm
@@ -1,163 +1,191 @@
 module WebGL.Settings
     exposing
         ( Setting
-        , enable
-        , disable
-        , blendColor
-        , blendEquation
-        , blendEquationSeparate
-        , blendFunc
-        , clearColor
-        , depthFunc
-        , depthMask
+        , blend
+        , BlendOptions
+        , blendOptions
+        , blendSeparate
+        , depth
+        , DepthOptions
+        , depthOptions
+        , stencil
+        , StencilOptions
+        , stencilOptions
+        , stencilSeparate
+          -- todo:
         , sampleCoverageFunc
-        , stencilFunc
-        , stencilFuncSeparate
-        , stencilOperation
-        , stencilOperationSeparate
-        , stencilMask
         , colorMask
         , scissor
+        , enable
+        , clearColor
         )
 
 {-| The `WebGL.Setting` provides a typesafe way to call
 all pre-fragment operations and some special functions.
 
 # Settings
-@docs Setting, enable, disable, blendColor, blendEquation, blendEquationSeparate, blendFunc, clearColor, depthFunc, depthMask, sampleCoverageFunc, stencilFunc, stencilFuncSeparate, stencilOperation, stencilOperationSeparate, stencilMask, colorMask, scissor
+@docs Setting, enable, clearColor, sampleCoverageFunc, colorMask, scissor
+
+# Blending
+
+@docs blend, blendSeparate, BlendOptions, blendOptions
+
+# Depth Test
+
+@docs depth, DepthOptions, depthOptions
+
+# Stencil Test
+
+@docs stencil, StencilOptions, stencilOptions, stencilSeparate
 
 -}
 
-import WebGL.Constants exposing (..)
+import WebGL.Constants
 
 
 {-| To initiate a `Setting` please use one of the following functions
 -}
 type Setting
-    = Enable Int
-    | Disable Int
-    | BlendColor Float Float Float Float
-    | BlendEquation Int
-    | BlendEquationSeparate Int Int
-    | BlendFunc Int Int
-    | ClearColor Float Float Float Float
-    | DepthFunc Int
-    | DepthMask Bool
+    = Blend BlendOptions Float Float Float Float
+    | BlendSeparate BlendOptions BlendOptions Float Float Float Float
+    | Depth DepthOptions
+    | Stencil StencilOptions
+    | StencilSeparate StencilOptions StencilOptions
     | SampleCoverageFunc Float Bool
-    | StencilFunc Int Int Int
-    | StencilFuncSeparate Int Int Int Int
-    | StencilOperation Int Int Int
-    | StencilOperationSeparate Int Int Int Int
-    | StencilMask Int
     | ColorMask Bool Bool Bool Bool
     | Scissor Int Int Int Int
+    | Enable Int
+    | ClearColor Float Float Float Float
 
 
-{-| `enable capability`
-enable server-side GL capabilities
+{-| Blend setting allows to control how the source and destination
+colors are blended. Initiate it with BlendOptions and
+red green blue alpha color components, that are from 0 to 1.
 -}
-enable : Capability -> Setting
-enable (Capability capability) =
-    Enable capability
+blend : BlendOptions -> Float -> Float -> Float -> Float -> Setting
+blend =
+    Blend
 
 
-{-| `disable capability`
-disable server-side GL capabilities
--}
-disable : Capability -> Setting
-disable (Capability capability) =
-    Disable capability
+{-| Defines options for the blend setting
 
+* `equation` specifies how source and destination color components are combined
+* `source` specifies how the source blending factors are computed
+* `destination` specifies how the destination blending factors are computed
 
-{-| `blendColor red green blue alpha`
-set the blend color
+srcAlphaSaturate should only be used for the source.
 
-Requires blend to be enabled.
-
--}
-blendColor : Float -> Float -> Float -> Float -> Setting
-blendColor =
-    BlendColor
-
-
-{-| `blendEquation mode`
-specify the equation used for both the
-RGB blend equation and the Alpha blend equation
-
-Requires blend to be enabled.
-
-+ `mode`: specifies how source and destination colors are combined
--}
-blendEquation : BlendMode -> Setting
-blendEquation (BlendMode blendMode) =
-    BlendEquation blendMode
-
-
-{-| `blendEquationSeparate modeRGB modeAlpha`
-set the RGB blend equation and the alpha blend equation separately
-
-Requires blend to be enabled.
-
-+ `modeRGB`: specifies the RGB blend equation, how the red, green,
-and blue components of the source and destination colors are combined
-+ `modeAlpha`: specifies the alpha blend equation, how the alpha component
-of the source and destination colors are combined
--}
-blendEquationSeparate : BlendMode -> BlendMode -> Setting
-blendEquationSeparate (BlendMode modeRGB) (BlendMode modeAlpha) =
-    BlendEquationSeparate modeRGB modeAlpha
-
-
-{-| `blendFunc srcFactor dstFactor`
-specify pixel arithmetic
-
-Requires blend to be enabled.
-
-+ `srcFactor`: Specifies how the red, green, blue,
-and alpha source blending factors are computed
-+ `dstFactor`: Specifies how the red, green, blue,
-and alpha destination blending factors are computed
-
-`SrcAlphaSaturate` should only be used for the srcFactor.
-
-Both values may not reference a `ConstantColor` value.
--}
-blendFunc : BlendOperation -> BlendOperation -> Setting
-blendFunc (BlendOperation srcFactor) (BlendOperation dstFactor) =
-    BlendFunc srcFactor dstFactor
-
-
-{-| `clearColor red green blue alpha`
-set the clear/background color,
-should be set before clearing the scene
--}
-clearColor : Float -> Float -> Float -> Float -> Setting
-clearColor =
-    ClearColor
-
-
-{-| `depthFunc func`
-specify the value used for depth buffer comparisons
-
-Requires depthTest to be enabled.
-
-+ `func`: Specifies the depth comparison function
--}
-depthFunc : CompareMode -> Setting
-depthFunc (CompareMode func) =
-    DepthFunc func
-
-
-{-| `depthMask mask`
-
-Turns drawing to the depth buffer on or off.
-
-Requires depthTest to be enabled.
+constantColor and constantAlpha values should not be used together
+as source and destination.
 
 -}
-depthMask : Bool -> Setting
-depthMask =
-    DepthMask
+type alias BlendOptions =
+    { equation : WebGL.Constants.BlendEquation
+    , source : WebGL.Constants.BlendFactor
+    , destination : WebGL.Constants.BlendFactor
+    }
+
+
+{-| Defaut options for the blend setting
+-}
+blendOptions : BlendOptions
+blendOptions =
+    { equation = WebGL.Constants.add
+    , source = WebGL.Constants.one
+    , destination = WebGL.Constants.zero
+    }
+
+
+{-| The same as blend setting, but allows to pass separate
+blend options for color channels and alpha channel
+-}
+blendSeparate : BlendOptions -> BlendOptions -> Float -> Float -> Float -> Float -> Setting
+blendSeparate =
+    BlendSeparate
+
+
+{-| Activates depth comparisons and updates to the depth buffer.
+Initiate it with DepthOptions.
+-}
+depth : DepthOptions -> Setting
+depth =
+    Depth
+
+
+{-| Defines options for the depth setting
+
+* `func` specifies a function that compares incoming pixel depth to the current depth buffer value
+* `mask` specifies whether the depth buffer is enabled for writing
+* `near` specifies the mapping of the near clipping plane to window coordinates
+* `far` specifies the mapping of the far clipping plane to window coordinates
+-}
+type alias DepthOptions =
+    { func : WebGL.Constants.CompareMode
+    , mask : Bool
+    , near : Float
+    , far : Float
+    }
+
+
+{-| Defaut options for the depth setting
+-}
+depthOptions : DepthOptions
+depthOptions =
+    { func = WebGL.Constants.less
+    , mask = True
+    , near = 0
+    , far = 1
+    }
+
+
+{-| Activates stencil testing and updates to the stencil buffer.
+Initiate it with StencilOptions.
+-}
+stencil : StencilOptions -> Setting
+stencil =
+    Stencil
+
+
+{-| Defines options for the stencil setting
+
+* `func` - the test function
+* `ref` - the reference value for the stencil test, clamped to the range 0 to 2^n - 1, n is the number of bitplanes in the stencil buffer
+* `valueMask` - bit-wise mask that is used to AND the reference value and the stored stencil value when the test is done
+* `fail` - the function to use when the stencil test fails
+* `zfail` - the function to use when the stencil test passes, but the depth test fails
+* `zpass` - the function to use when both the stencil test and the depth test pass, or when the stencil test passes and there is no depth buffer or depth testing is disabled
+* `writeMask` - a bit mask to enable or disable writing of individual bits in the stencil plane
+-}
+type alias StencilOptions =
+    { func : WebGL.Constants.CompareMode
+    , ref : Int
+    , valueMask : Int
+    , fail : WebGL.Constants.ZMode
+    , zfail : WebGL.Constants.ZMode
+    , zpass : WebGL.Constants.ZMode
+    , writeMask : Int
+    }
+
+
+{-| Defaut options for the stencil setting
+-}
+stencilOptions : StencilOptions
+stencilOptions =
+    { func = WebGL.Constants.always
+    , ref = 0
+    , valueMask = 4294967295
+    , fail = WebGL.Constants.keep
+    , zfail = WebGL.Constants.keep
+    , zpass = WebGL.Constants.keep
+    , writeMask = 4294967295
+    }
+
+
+{-| separate settings for front- and back-facing polygons
+-}
+stencilSeparate : StencilOptions -> StencilOptions -> Setting
+stencilSeparate =
+    StencilSeparate
 
 
 {-| `sampleCoverageFunc value invert`
@@ -173,84 +201,6 @@ if the coverage masks should be inverted. The initial value is `False`
 sampleCoverageFunc : Float -> Bool -> Setting
 sampleCoverageFunc =
     SampleCoverageFunc
-
-
-{-| `stencilFunc func ref mask`
-set front and back function and reference value for stencil testing
-
-Requires stencilTest to be enabled.
-
-+ `func`: Specifies the test function.  The initial value is `Always`
-+ `ref`: Specifies the reference value for the stencil test. ref is
-clamped to the range 0 2 n - 1 , n is the number of bitplanes
-in the stencil buffer. The initial value is `0`.
-+ `mask`: Specifies a mask that is ANDed with both the reference value
-and the stored stencil value when the test is done.
-The initial value is all `1`'s.
--}
-stencilFunc : CompareMode -> Int -> Int -> Setting
-stencilFunc (CompareMode func) =
-    StencilFunc func
-
-
-{-| `stencilFuncSeparate face func ref mask`
-set front and/or back function and reference value for stencil testing
-
-Requires stencilTest to be enabled.
-
-+ `face`: Specifies whether front and/or back stencil state is updated
-
-See the description of `stencilFunc` for info about the other parameters
--}
-stencilFuncSeparate : FaceMode -> CompareMode -> Int -> Int -> Setting
-stencilFuncSeparate (FaceMode face) (CompareMode func) =
-    StencilFuncSeparate face func
-
-
-{-| `stencilOperation fail zfail pass`
-set front and back stencil test actions
-
-Requires stencilTest to be enabled.
-
-+ `fail`: Specifies the action to take when the stencil test fails.
-The initial value is `Keep`
-+ `zfail`: Specifies the stencil action when the stencil test passes,
-but the depth test fails. The initial value is `Keep`
-+ `pass`: Specifies the stencil action when both the stencil test
-and the depth test pass, or when the stencil test passes and either
-there is no depth buffer or depth testing is not enabled.
-The initial value is `Keep`
--}
-stencilOperation : ZMode -> ZMode -> ZMode -> Setting
-stencilOperation (ZMode fail) (ZMode zfail) (ZMode pass) =
-    StencilOperation fail zfail pass
-
-
-{-| stencilOperationSeparate face fail zfail pass`
-set front and/or back stencil test actions
-
-Requires stencilTest to be enabled.
-
-+ `face`: Specifies whether front and/or back stencil state is updated.
-
-See the description of `StencilOperation` for info about the other parameters.
--}
-stencilOperationSeparate : FaceMode -> ZMode -> ZMode -> ZMode -> Setting
-stencilOperationSeparate (FaceMode face) (ZMode fail) (ZMode zfail) (ZMode pass) =
-    StencilOperationSeparate face fail zfail pass
-
-
-{-| `stencilMask mask`
-set the stencil `mask`. This value is ANDed with anything drawn to the
-stencil buffer. Usually used to turn writing to the stencil buffer
-on or off.
-
-Requires stencilTest to be enabled.
-
--}
-stencilMask : Int -> Setting
-stencilMask =
-    StencilMask
 
 
 {-| `colorMask red green blue alpha`
@@ -273,3 +223,20 @@ Requires scissorTest to be enabled.
 scissor : Int -> Int -> Int -> Int -> Setting
 scissor =
     Scissor
+
+
+{-| `enable capability`
+enable server-side GL capabilities
+-}
+enable : WebGL.Constants.Capability -> Setting
+enable (WebGL.Constants.Capability capability) =
+    Enable capability
+
+
+{-| `clearColor red green blue alpha`
+set the clear/background color,
+should be set before clearing the scene
+-}
+clearColor : Float -> Float -> Float -> Float -> Setting
+clearColor =
+    ClearColor

--- a/src/WebGL/Settings.elm
+++ b/src/WebGL/Settings.elm
@@ -14,6 +14,9 @@ module WebGL.Settings
         , stencilSeparate
         , scissor
         , colorMask
+        , cullFace
+        , dither
+        , polygonOffset
           -- todo:
         , sampleCoverageFunc
         , enable
@@ -40,7 +43,7 @@ all pre-fragment operations and some special functions.
 
 # Other settings
 
-@docs scissor, colorMask, enable, sampleCoverageFunc
+@docs scissor, colorMask, cullFace, dither, polygonOffset, enable, sampleCoverageFunc
 
 -}
 
@@ -57,6 +60,9 @@ type Setting
     | StencilSeparate StencilOptions StencilOptions
     | Scissor Int Int Int Int
     | ColorMask Bool Bool Bool Bool
+    | CullFace Int
+    | Dither
+    | PolygonOffset Float Float
     | SampleCoverageFunc Float Bool
     | Enable Int
     | ClearColor Float Float Float Float
@@ -209,6 +215,38 @@ should be written into the frame buffer.
 colorMask : Bool -> Bool -> Bool -> Bool -> Setting
 colorMask =
     ColorMask
+
+
+{-| Cull polygons based on their winding in window coordinates.
+
+Polygons with counter-clock-wise winding are front-facing .
+
+-}
+cullFace : WebGL.Constants.FaceMode -> Setting
+cullFace (WebGL.Constants.FaceMode faceMode) =
+    CullFace faceMode
+
+
+{-| Dither color components or indices before they
+are written to the color buffer.
+-}
+dither : Setting
+dither =
+    Dither
+
+
+{-| Add an offset to depth values of a polygon's fragments
+produced by rasterization. The offset is added before the depth
+test is performed and before the value is written into the depth buffer.
+
+* `factor` the first argument is the scale factor for the variable depth offset for each polygon.
+* `units` the second argument is the multiplier by which an implementation-specific value is multiplied
+  with to create a constant depth offset.
+
+-}
+polygonOffset : Float -> Float -> Setting
+polygonOffset =
+    PolygonOffset
 
 
 {-| `sampleCoverageFunc value invert`

--- a/src/WebGL/Settings.elm
+++ b/src/WebGL/Settings.elm
@@ -12,10 +12,10 @@ module WebGL.Settings
         , StencilOptions
         , stencilOptions
         , stencilSeparate
+        , scissor
+        , colorMask
           -- todo:
         , sampleCoverageFunc
-        , colorMask
-        , scissor
         , enable
         , clearColor
         )
@@ -24,7 +24,8 @@ module WebGL.Settings
 all pre-fragment operations and some special functions.
 
 # Settings
-@docs Setting, enable, clearColor, sampleCoverageFunc, colorMask, scissor
+
+@docs Setting
 
 # Blending
 
@@ -37,6 +38,10 @@ all pre-fragment operations and some special functions.
 # Stencil Test
 
 @docs stencil, StencilOptions, stencilOptions, stencilSeparate
+
+# Other settings
+
+@docs scissor, colorMask, enable, clearColor, sampleCoverageFunc
 
 -}
 
@@ -51,9 +56,10 @@ type Setting
     | Depth DepthOptions
     | Stencil StencilOptions
     | StencilSeparate StencilOptions StencilOptions
-    | SampleCoverageFunc Float Bool
-    | ColorMask Bool Bool Bool Bool
     | Scissor Int Int Int Int
+    | ColorMask Bool Bool Bool Bool
+      -- todo:
+    | SampleCoverageFunc Float Bool
     | Enable Int
     | ClearColor Float Float Float Float
 
@@ -188,6 +194,25 @@ stencilSeparate =
     StencilSeparate
 
 
+{-| Set the scissor box, which limits the drawing of fragments to the
+screen to a specified rectangle.
+
+The arguments are the coordinates of the lower left corner, width and height.
+
+-}
+scissor : Int -> Int -> Int -> Int -> Setting
+scissor =
+    Scissor
+
+
+{-| Specify whether or not each channel (red, green, blue, alpha)
+should be written into the frame buffer.
+-}
+colorMask : Bool -> Bool -> Bool -> Bool -> Setting
+colorMask =
+    ColorMask
+
+
 {-| `sampleCoverageFunc value invert`
 specify multisample coverage parameters
 
@@ -201,28 +226,6 @@ if the coverage masks should be inverted. The initial value is `False`
 sampleCoverageFunc : Float -> Bool -> Setting
 sampleCoverageFunc =
     SampleCoverageFunc
-
-
-{-| `colorMask red green blue alpha`
-
-Specify whether or not each channel should be written into the frame buffer.
-
--}
-colorMask : Bool -> Bool -> Bool -> Bool -> Setting
-colorMask =
-    ColorMask
-
-
-{-| `scissor x y width height`
-set the scissor box, which limits the drawing of fragments to the
-screen to a specified rectangle.
-
-Requires scissorTest to be enabled.
-
--}
-scissor : Int -> Int -> Int -> Int -> Setting
-scissor =
-    Scissor
 
 
 {-| `enable capability`


### PR DESCRIPTION
This is WIP on grouping settings, so we can be clever about enabling/disabling gl features and explicit about the default values.

Before, each function call would modify the environment for the next renderable. 
With these changes, we won't need to call `gl.enable/disable`, as we were doing in the `crate.elm` example that now has cool reflection effect thanks to @Zinggi.

![crate](https://cloud.githubusercontent.com/assets/43472/21067967/09ad80d0-be6f-11e6-8113-c2e7a8b015d8.gif)
