### PR TITLE
The first-person example did not work for me in Chrome on MacOS 10.10.5

### DIFF
--- a/examples/first-person.elm
+++ b/examples/first-person.elm
@@ -202,7 +202,6 @@ view { size, person, texture } =
         ]
         [ WebGL.toHtmlWith
             [ WebGL.depth 1
-            , WebGL.antialias
             ]
             [ width size.width
             , height size.height


### PR DESCRIPTION
The first-person example did not work for me in Chrome on MacOS 10.10.5 with all
extensions disabled and all chrome flags at defaults. Per direction from
'@unsoundscapes' on Slack I changed the first-person code per this commit and
the example then works for me in Chrome.