### PR TITLE
Add support for GLSL dFdx, dFdy, and fwidth

### DIFF
--- a/src/Native/WebGL.js
+++ b/src/Native/WebGL.js
@@ -601,6 +601,11 @@ var _elm_community$webgl$Native_WebGL = function () {
             gl.clearStencil(s1);
           });
           break;
+        case 'StandardDerivatives':
+          sceneSettings.push(function (gl) {
+            gl.getExtension('OES_standard_derivatives');
+          });
+          break;
       }
     }, model.options);
 
@@ -612,7 +617,6 @@ var _elm_community$webgl$Native_WebGL = function () {
     );
 
     if (gl) {
-      gl.getExtension('OES_standard_derivatives');
       sceneSettings.forEach(function (sceneSetting) {
         sceneSetting(gl);
       });

--- a/src/Native/WebGL.js
+++ b/src/Native/WebGL.js
@@ -612,6 +612,7 @@ var _elm_community$webgl$Native_WebGL = function () {
     );
 
     if (gl) {
+      gl.getExtension('OES_standard_derivatives');
       sceneSettings.forEach(function (sceneSetting) {
         sceneSetting(gl);
       });

--- a/src/WebGL.elm
+++ b/src/WebGL.elm
@@ -22,6 +22,7 @@ module WebGL
         , stencil
         , antialias
         , clearColor
+        , standardDerivatives
         , unsafeShader
         )
 
@@ -44,7 +45,7 @@ before trying to do too much with just the documentation provided here.
 
 # Advanced Usage
 @docs entityWith, toHtmlWith, Option, alpha, depth, stencil, antialias,
-  clearColor
+  clearColor, standardDerivatives
 
 # Meshes
 @docs indexedTriangles, lines, lineStrip, lineLoop, points, triangleFan,
@@ -305,6 +306,7 @@ type Option
     | Stencil Int
     | Antialias
     | ClearColor Float Float Float Float
+    | StandardDerivatives
 
 
 {-| Enable alpha channel in the drawing buffer. If the argument is `True`, then
@@ -350,3 +352,32 @@ clamped between 0 and 1. The default is all 0's.
 clearColor : Float -> Float -> Float -> Float -> Option
 clearColor =
     ClearColor
+
+
+{-| Enable the [standard derivatives](https://developer.mozilla.org/en-US/docs/Web/API/OES_standard_derivatives)
+extension, allowing the use of `dFdx`, `dFdy` and `fwidth` in fragment shaders.
+In addition to setting this option, any fragment shader that uses these
+functions must include
+
+```c
+#extension GL_OES_standard_derivatives : enable
+```
+
+as the first line. To allow compatibility with browsers that do not support this
+extension, you can use
+
+```c
+#ifdef GL_OES_standard_derivatives
+// compute values using dFdx, dFdy, fwidth
+#else
+// compute values using some other method
+#endif
+```
+
+in your fragment shader (in addition to the `#extension` line) to conditionally
+compile different shader logic based on whether the extension is available or
+not.
+-}
+standardDerivatives : Option
+standardDerivatives =
+    StandardDerivatives


### PR DESCRIPTION
These 'standard derivative' functions are very useful for a variety of techniques such as edge detection and blurring without requiring a second rendering pass. They seem to have very good support across most browsers:

- [This post](http://codeflow.org/entries/2012/apr/25/webgl-statistics-and-the-state-of-webgl-html5/#shader-standard-derivatives) back from 2012 shows good support across browsers and recommends "Can use: Yes"
- [webglstats.com](http://webglstats.com/webg/extension/OES_standard_derivatives) shows near-100% support nowadays
- three.js enables the extension in [several different circumstances](https://github.com/mrdoob/three.js/blob/master/src/renderers/webgl/WebGLProgram.js#L87)
- These functions are [made standard in WebGL 2](https://developer.mozilla.org/en-US/docs/Web/API/OES_standard_derivatives)

I believe this change should be safe even on browsers that don't support the extension (not sure how to test this!), since `getExtension()` simply [returns null](https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API/Using_Extensions#Enabling_an_extension) if the extension is not available. Additionally, individual fragment shaders must still explicitly enable the extension by adding

```glsl
#extension GL_OES_standard_derivatives : enable
```

as the first line, so there is a strong hint to the shader writer that using these functions *may* not work on all browsers.

Unfortunately Elm's GLSL parser doesn't seem to recognize `#extension` as valid syntax; ideally that would be fixed in the upstream Haskell package, but in the meantime the workaround is to use `unsafeShader`.

**Update:** I've added `standardDerivatives` as an `Option` that must be explicitly enabled, since there's at least [one report](https://github.com/kripken/emscripten/issues/5147) of extension-loading having measurable performance impact.

As mentioned in the documentation I added for `WebGL.standardDerivatives`, it's possible to detect the presence or absence of the extension using [`#ifdef GL_OES_standard_derivatives`](https://www.khronos.org/registry/webgl/extensions/OES_standard_derivatives/) in the fragment shader to conditionally compile different fragment shader code ([example](https://github.com/opensolid/sketch3d/blob/master/src/OpenSolid/Sketch3d.elm#L774)).

As far as I can tell, calling `getExtension()` to attempt to enable a non-available extension (or enabling one that is then not used) has no effect other than the time taken to call `getExtension()`. Shaders will only fail to compile (potential runtime error) if `dFdx` etc. is used outside of an `#ifdef GL_OES_standard_derivatives` block, on a browser where standard derivatives are not supported.

## What to do about `[glsl|...|]` parsing?

Right now, as mentioned above, Elm's GLSL parser doesn't recognize `#extension` lines (or even `#ifdef`, actually) so any shader using them has to be created with `unsafeShader`, which is messy. Additionally, if uniforms, attributes or varyings were added within `#ifdef` blocks then the inferred Elm type of the shader would change depending on the presence of the extension! Some potential solutions:

  - Update the GLSL parser to recognize `#extension` and `#ifdef`, and disallow declaration of uniforms, attributes or varyings inside an `#ifdef`. Most flexible, but requires the most work. (This is the 'perfect world' that the current `WebGL.standardDerivatives` documentation text assumes...)
  - Keep the GLSL parser as-is, and internally prepend "#extension GL_OES_standard_derivatives : enable\n" to the resulting shader string if the `StandardDerivatives` option has been enabled. This way the shader writer doesn't have to remember to add the `#extension` line to their shaders (just call `WebGL.toHtmlWith` with `WebGL.standardDerivatives` as one of the options, then go ahead and start using `dFdx` etc.). Since the GLSL parser also doesn't seem to support `#ifdef`, I think in this case the approach would be "if you want to use `dFdx` and friends, just realize that it *may* not work cross-browser". (It seems to me, though, that for practical purposes it's pretty safe to assume that the extension is available anywhere that WebGL is.) If people really want to support both cases, then there's always `unsafeShader`...
  - Don't support the standard derivatives at all ☹️ 