### PR TITLE
Fix unnecessary linear-time emptiness check

### DIFF
--- a/src/Native/WebGL.js
+++ b/src/Native/WebGL.js
@@ -368,7 +368,7 @@ var _elm_community$webgl$Native_WebGL = function () {
     LOG('Drawing');
 
     function drawEntity(entity) {
-      if (listLength(entity.buffer._0) === 0) {
+      if (entity.buffer._0.ctor === '[]') {
         return;
       }
 


### PR DESCRIPTION
Previously, `drawEntity` checked if a buffer list was empty by computing its length and comparing it to zero.  This required a linear-time traversal of the entire list.  All that is really needed is to check if the list is empty or not, which can be done in constant time by checking if its constructor is `[]`.