### PR TITLE
Add preserveDrawingBuffer option

### DIFF
--- a/src/Native/WebGL.js
+++ b/src/Native/WebGL.js
@@ -570,7 +570,8 @@ var _elm_community$webgl$Native_WebGL = function () {
       depth: false,
       stencil: false,
       antialias: false,
-      premultipliedAlpha: false
+      premultipliedAlpha: false,
+      preserveDrawingBuffer: false
     };
     var sceneSettings = [];
 
@@ -600,6 +601,9 @@ var _elm_community$webgl$Native_WebGL = function () {
           sceneSettings.push(function (gl) {
             gl.clearStencil(s1);
           });
+          break;
+        case 'PreserveDrawingBuffer':
+          contextAttributes.preserveDrawingBuffer = true;
           break;
       }
     }, model.options);

--- a/src/WebGL.elm
+++ b/src/WebGL.elm
@@ -316,6 +316,7 @@ type Option
     | Stencil Int
     | Antialias
     | ClearColor Float Float Float Float
+    | PreserveDrawingBuffer
 
 
 {-| Enable alpha channel in the drawing buffer. If the argument is `True`, then

--- a/src/WebGL.elm
+++ b/src/WebGL.elm
@@ -22,6 +22,7 @@ module WebGL
         , stencil
         , antialias
         , clearColor
+        , preserveDrawingBuffer
         , unsafeShader
         )
 
@@ -44,7 +45,7 @@ before trying to do too much with just the documentation provided here.
 
 # Advanced Usage
 @docs entityWith, toHtmlWith, Option, alpha, depth, stencil, antialias,
-  clearColor
+  clearColor, preserveDrawingBuffer
 
 # Meshes
 @docs indexedTriangles, lines, lineStrip, lineLoop, points, triangleFan,
@@ -360,3 +361,14 @@ clamped between 0 and 1. The default is all 0's.
 clearColor : Float -> Float -> Float -> Float -> Option
 clearColor =
     ClearColor
+
+{-| By default, WebGL canvas swaps drawing and display buffers. 
+This option forces it to copy the drawing buffer into the display buffer.
+
+Even though this slows down the rendering, it allows you to extract the image from 
+the canvas element using `canvas.toBlob()` in JavaScript without having to worry 
+about the synchronization between frames.
+-}
+preserveDrawingBuffer : Option
+preserveDrawingBuffer =
+    PreserveDrawingBuffer


### PR DESCRIPTION

There is a need to read image from the canvas in JavaScript. Due to WebGL nature, you have to enable the preserveDrawingBuffer option in order to be able to do this reliably.

A sample use case might be [recording a gif from the WebGL rendering](https://github.com/w0rm/elm-webgl-playground/tree/master/Gif). Originally requested for http://elmation.com in [this reddit post](https://www.reddit.com/r/elm/comments/81nud0/how_to_get_webgl_context_gl_from_elm_webgl/) but it is possible to do it without exposing gl context.


![gif](https://user-images.githubusercontent.com/43472/36947012-7c680186-1fc6-11e8-80dc-1e42378a229c.gif)
